### PR TITLE
Default buffer size update

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Currently supported options:
 | Name | Since | Example | Description |
 |------|:-----:|:-------:|-------------|
 | `version` | `0.0.1` | _5, 7_ | version to use when parsing NetFlow files, your own version provider can be passed
-| `buffer` | `0.0.2` | _1024, 32Kb, 3Mb, etc_ | buffer size for NetFlow compressed stream (default: `3Mb`)
+| `buffer` | `0.0.2` | _1024, 32Kb, 3Mb, etc_ | buffer size for NetFlow compressed stream (default: `1Mb`)
 | `stringify` | `0.0.2` | _true, false_ | convert certain fields (e.g. IP, protocol) into human-readable format, though it is recommended to turn it off when performance matters (default: `true`)
 | `predicate-pushdown` | `0.2.0` | _true, false_ | use predicate pushdown at NetFlow library level (default: `true`)
 | `partitions` | `0.2.1` | _default, auto, 1, 2, 100, 1024, etc_ | partition mode to use, can be `default`, `auto`, or any number of partitions (default: `default`)

--- a/src/main/java/com/github/sadikovi/netflowlib/Buffers.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/Buffers.java
@@ -44,6 +44,8 @@ public final class Buffers {
     public static final int MIN_BUFFER_LENGTH = 32768;
     // length of buffer in bytes ~3Mb (option 1)
     public static final int BUFFER_LENGTH_1 = 3698688;
+    // length of buffer in bytes ~1Mb (option 2)
+    public static final int BUFFER_LENGTH_2 = 1048576;
 
     public abstract Iterator<Object[]> iterator();
 

--- a/src/main/scala/com/github/sadikovi/spark/benchmark/Benchmark.scala
+++ b/src/main/scala/com/github/sadikovi/spark/benchmark/Benchmark.scala
@@ -76,7 +76,7 @@ private[spark] class Benchmark(
       printf("%-35s %16s %12s %13s %10s\n",
         benchmark.name,
         "%5.0f / %4.0f" format (result.bestMs, result.avgMs),
-        "%10.1f" format result.bestRate,
+        "%10.1f" format result.bestRate * 100000,
         "%6.1f" format (1000 / result.bestRate),
         "%3.1fX" format (firstBest / result.bestMs))
     }

--- a/src/main/scala/com/github/sadikovi/spark/benchmark/NetFlowReadBenchmark.scala
+++ b/src/main/scala/com/github/sadikovi/spark/benchmark/NetFlowReadBenchmark.scala
@@ -72,9 +72,9 @@ object NetFlowReadBenchmark {
     // scalastyle:on
 
     // Defined benchmarks
-    fullScanBenchmark(iterations, version, files)
-    predicateScanBenchmark(iterations, version, files)
-    aggregatedScanBenchmark(iterations, version, files)
+    // fullScanBenchmark(iterations, version, files)
+    // predicateScanBenchmark(iterations, version, files)
+    // aggregatedScanBenchmark(iterations, version, files)
     bufferSizeBenchmark(iterations, version, files)
   }
 
@@ -176,8 +176,7 @@ object NetFlowReadBenchmark {
       val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
         option("version", version).option("buffer", "32Kb").load(files).
         select("srcip", "dstip", "srcport", "dstport", "packets", "octets")
-      df.cache()
-      df.count()
+      df.foreach(_ => Unit)
     }
 
     // Buffer size of 64Kb
@@ -185,8 +184,7 @@ object NetFlowReadBenchmark {
       val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
         option("version", version).option("buffer", "64Kb").load(files).
         select("srcip", "dstip", "srcport", "dstport", "packets", "octets")
-      df.cache()
-      df.count()
+      df.foreach(_ => Unit)
     }
 
     // Buffer size of 1Mb
@@ -194,8 +192,7 @@ object NetFlowReadBenchmark {
       val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
         option("version", version).option("buffer", "1Mb").load(files).
         select("srcip", "dstip", "srcport", "dstport", "packets", "octets")
-      df.cache()
-      df.count()
+      df.foreach(_ => Unit)
     }
 
     // Buffer size of 3Mb
@@ -203,8 +200,7 @@ object NetFlowReadBenchmark {
       val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
         option("version", version).option("buffer", "3Mb").load(files).
         select("srcip", "dstip", "srcport", "dstport", "packets", "octets")
-      df.cache()
-      df.count()
+      df.foreach(_ => Unit)
     }
 
     sqlBenchmark.run()

--- a/src/main/scala/com/github/sadikovi/spark/benchmark/NetFlowReadBenchmark.scala
+++ b/src/main/scala/com/github/sadikovi/spark/benchmark/NetFlowReadBenchmark.scala
@@ -75,6 +75,7 @@ object NetFlowReadBenchmark {
     fullScanBenchmark(iterations, version, files)
     predicateScanBenchmark(iterations, version, files)
     aggregatedScanBenchmark(iterations, version, files)
+    bufferSizeBenchmark(iterations, version, files)
   }
 
   private def process(args: List[String], conf: Conf): Conf = args match {
@@ -162,6 +163,48 @@ object NetFlowReadBenchmark {
 
       val agg = df.groupBy(col("srcip"), col("dstip"), col("srcport"), col("dstport")).count()
       agg.count()
+    }
+
+    sqlBenchmark.run()
+  }
+
+  def bufferSizeBenchmark(iters: Int, version: String, files: String): Unit = {
+    val sqlBenchmark = new Benchmark("NetFlow buffer size report", 10000, iters)
+
+    // Buffer size of 32Kb
+    sqlBenchmark.addCase("Buffer size 32Kb") { iter =>
+      val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
+        option("version", version).option("buffer", "32Kb").load(files).
+        select("srcip", "dstip", "srcport", "dstport", "packets", "octets")
+      df.cache()
+      df.count()
+    }
+
+    // Buffer size of 64Kb
+    sqlBenchmark.addCase("Buffer size 64Kb") { iter =>
+      val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
+        option("version", version).option("buffer", "64Kb").load(files).
+        select("srcip", "dstip", "srcport", "dstport", "packets", "octets")
+      df.cache()
+      df.count()
+    }
+
+    // Buffer size of 1Mb
+    sqlBenchmark.addCase("Buffer size 1Mb") { iter =>
+      val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
+        option("version", version).option("buffer", "1Mb").load(files).
+        select("srcip", "dstip", "srcport", "dstport", "packets", "octets")
+      df.cache()
+      df.count()
+    }
+
+    // Buffer size of 3Mb
+    sqlBenchmark.addCase("Buffer size 3Mb") { iter =>
+      val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
+        option("version", version).option("buffer", "3Mb").load(files).
+        select("srcip", "dstip", "srcport", "dstport", "packets", "octets")
+      df.cache()
+      df.count()
     }
 
     sqlBenchmark.run()

--- a/src/main/scala/com/github/sadikovi/spark/netflow/NetFlowRelation.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/NetFlowRelation.scala
@@ -57,7 +57,7 @@ private[netflow] class NetFlowRelation(
       "number, e.g 5, 7, or can be fully-qualified class name for NetFlow interface")
   }
 
-  // Buffer size in bytes, by default use standard record buffer size ~3Mb
+  // Buffer size in bytes, by default use standard record buffer size ~1Mb
   private val bufferSize = parameters.get("buffer") match {
     case Some(str) =>
       val bytes = Utils.byteStringAsBytes(str)
@@ -70,7 +70,7 @@ private[netflow] class NetFlowRelation(
       } else {
         bytes.toInt
       }
-    case None => RecordBuffer.BUFFER_LENGTH_1
+    case None => RecordBuffer.BUFFER_LENGTH_2
   }
 
   // Conversion of numeric field into string, such as IP, by default is on

--- a/src/test/scala/com/github/sadikovi/spark/netflow/NetflowSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/NetflowSuite.scala
@@ -238,7 +238,7 @@ class NetFlowSuite extends UnitTestSpec with SparkLocal {
     // check that buffer size is default
     var params = Map("version" -> "5")
     var relation = new NetFlowRelation(Array(path1), None, None, params)(sqlContext)
-    relation.getBufferSize() should be (RecordBuffer.BUFFER_LENGTH_1)
+    relation.getBufferSize() should be (RecordBuffer.BUFFER_LENGTH_2)
 
     // set buffer size to be 64Kb
     params = Map("version" -> "5", "buffer" -> "64Kb")


### PR DESCRIPTION
This PR updates default buffer size from `3Mb` to `1Mb`.
Benchmarks (run only for `buffer size report`.

``` shell
- Iterations: 5
- Files: file:/Users/sadikovi/developer/spark-netflow/temp/ft*/*/ft*
- Version: 5
Running benchmark: NetFlow buffer size report

Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
NetFlow buffer size report:         Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------
Buffer size 32Kb                         1290 / 1388        775.1      129015.6       1.0X
Buffer size 64Kb                         1220 / 1233        819.6      122009.0       1.1X
Buffer size 1Mb                          1176 / 1199        850.2      117618.0       1.1X
Buffer size 3Mb                          1185 / 1219        843.9      118502.5       1.1X
```
