### PR TITLE
Add statistics to NetFlow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ libraryDependencies ++= Seq(
 )
 
 // check deprecation without manual restart
-scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")
+scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation", "-feature")
 
 // Display full-length stacktraces from ScalaTest:
 testOptions in Test += Tests.Argument("-oF")

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,5 +2,9 @@ comment:
   layout: header, changes, diff
 coverage:
   status:
-    patch: true
-    changes: false
+    project:
+      enabled: true
+    patch:
+      enabled: true
+    changes:
+      enabled: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: header, changes, diff
+coverage:
+  status:
+    patch: true
+    changes: false

--- a/src/main/scala/com/github/sadikovi/spark/netflow/NetFlowFilters.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/NetFlowFilters.scala
@@ -88,7 +88,7 @@ private[spark] object NetFlowFilters {
 
   /**
    * Update filter predicate based on attribute map. Column name of filter predicate is used as a
-   * Key of the attribute map to extract relevant attribute. For different predicate different
+   * key of the attribute map to extract relevant attribute. For different predicate different
    * statistics data is used. No-op when attribute is not found, or filter is trivial.
    */
   def updateFilter(filter: FilterPredicate, attributes: AttributeMap): FilterPredicate = {

--- a/src/main/scala/com/github/sadikovi/spark/netflow/NetFlowRelation.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/NetFlowRelation.scala
@@ -190,7 +190,7 @@ private[netflow] class NetFlowRelation(
         NetFlowFileStatus(interface.version(), filePath, fileLen, bufferSize, statisticsPath)
       }
 
-      // Return `NetFlowFileRDD`, we store data of each file in individual partition
+      // Return `NetFlowFileRDD`, we store data of each file based on provided partition mode
       new NetFlowFileRDD(sqlContext.sparkContext, fileStatuses, partitionMode, applyConversion,
         resolvedColumns, resolvedFilter)
     }
@@ -206,6 +206,7 @@ private[netflow] class NetFlowRelation(
       s"partition mode $partitionMode, " +
       s"buffer size $bufferSize, " +
       s"predicate pushdown $usePredicatePushdown, " +
+      s"statistics $pathResolver, " +
       s"conversion: $applyConversion)"
   }
 }

--- a/src/main/scala/com/github/sadikovi/spark/netflow/NetFlowRelation.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/NetFlowRelation.scala
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory
 
 import com.github.sadikovi.netflowlib.Buffers.RecordBuffer
 import com.github.sadikovi.netflowlib.predicate.Operators.FilterPredicate
+import com.github.sadikovi.spark.netflow.index.StatisticsPathResolver
 import com.github.sadikovi.spark.netflow.sources._
 import com.github.sadikovi.spark.rdd.NetFlowFileRDD
 import com.github.sadikovi.spark.util.Utils

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/Attribute.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/Attribute.scala
@@ -112,15 +112,43 @@ class Attribute[T](
     if (isSetEnabled) Some(set) else None
   }
 
-  /** Check if value is in min-max range, if mode is enabled, otherwise None */
-  def containsInRange(value: Any): Option[Boolean] = {
+  /**
+   * Generic method to check boundaries for min/max statistics.
+   * Function parameters are min, value, max.
+   */
+  private def boundaryQuery(value: Any)(func: (T, T, T) => Boolean): Option[Boolean] = {
     if (isMinMaxEnabled) {
       val updatedValue = value.asInstanceOf[T]
-      // null value is always out of range, false is returned
-      if (value != null) Some(!lt(updatedValue, min) && !lt(max, updatedValue)) else Some(false)
+      // null value is always out of range and does not confirm to predicate, false is returned
+      if (value != null) Some(func(min, updatedValue, max)) else Some(false)
     } else {
       None
     }
+  }
+
+  /** Check if value is in min-max range, if mode is enabled, otherwise None */
+  def containsInRange(value: Any): Option[Boolean] = {
+    boundaryQuery(value) { (min, v, max) => !lt(v, min) && !lt(max, v) }
+  }
+
+  /** Check if value is greater than max */
+  def lessThanMax(value: Any): Option[Boolean] = {
+    boundaryQuery(value) { (min, v, max) => lt(v, max) }
+  }
+
+  /** Check if value is greater than or equal to max */
+  def lessOrEqualMax(value: Any): Option[Boolean] = {
+    boundaryQuery(value) { (min, v, max) => !lt(max, v) }
+  }
+
+  /** Check if value is less than min */
+  def greaterThanMin(value: Any): Option[Boolean] = {
+    boundaryQuery(value) { (min, v, max) => lt(min, v) }
+  }
+
+  /** Check if value is less than or equal to min */
+  def greaterOrEqualMin(value: Any): Option[Boolean] = {
+    boundaryQuery(value) { (min, v, max) => !lt(v, min) }
   }
 
   /** Check if value is in set, if mode is enabled, otherwise None */

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/AttributeMap.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/AttributeMap.scala
@@ -51,6 +51,43 @@ private[spark] class AttributeMap {
     }
   }
 
+  /** Query attribute for unresolved value */
+  private def query(
+      key: String, value: Any)(func: (Attribute[_], Any) => Option[Boolean]): Option[Boolean] = {
+    val attribute = map.get(key)
+    if (attribute.isEmpty) None else func(attribute.get, value)
+  }
+
+  /** Check if value is in attribute range for a specified key */
+  def between(key: String, value: Any): Option[Boolean] = {
+    query(key, value) { (attr, v) => attr.containsInRange(v) }
+  }
+
+  /** Check if value is less than attribute max for a specified key */
+  def ltMax(key: String, value: Any): Option[Boolean] = {
+    query(key, value) { (attr, v) => attr.lessThanMax(v) }
+  }
+
+  /** Check if value is less than or equal to attribute max for a specified key */
+  def leMax(key: String, value: Any): Option[Boolean] = {
+    query(key, value) { (attr, v) => attr.lessOrEqualMax(v) }
+  }
+
+  /** Check if value is greater than attribute min for a specified key */
+  def gtMin(key: String, value: Any): Option[Boolean] = {
+    query(key, value) { (attr, v) => attr.greaterThanMin(v) }
+  }
+
+  /** Check if value is greater than or equal to attribute min for a specified key */
+  def geMin(key: String, value: Any): Option[Boolean] = {
+    query(key, value) { (attr, v) => attr.greaterOrEqualMin(v) }
+  }
+
+  /** Check if value is in attribute set for a specified key */
+  def in(key: String, value: Any): Option[Boolean] = {
+    query(key, value) { (attr, v) => attr.containsInSet(v) }
+  }
+
   /** Return writer for this attribute map */
   def write(path: String): Unit = {
     val writer = new StatisticsWriter(ByteOrder.BIG_ENDIAN, map.values.toSeq)
@@ -72,6 +109,8 @@ object AttributeMap {
       Attribute[Int]("dstport", 6) ::
       Attribute[Short]("protocol", 6) ::
       Nil)
+
+  def empty(): AttributeMap = new AttributeMap()
 
   def read(path: String): AttributeMap = {
     val reader = new StatisticsReader()

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/AttributeMap.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/AttributeMap.scala
@@ -104,6 +104,9 @@ private[spark] class AttributeMap {
 /**
  * Interface to create or load attribute map.
  * When creating new attribute map returns map with predefined set of statistics.
+ * Note that number, name and type of attributes should be in sync with resolved interface columns,
+ * meaning that columns with attribute names should have statistics enabled, otherwise it will not
+ * collect anything, resulting in incorrect filtering.
  */
 object AttributeMap {
   def create(): AttributeMap =

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/AttributeMap.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/AttributeMap.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.spark.netflow.index
+
+import java.nio.ByteOrder
+
+import scala.collection.mutable.HashMap
+
+/**
+ * [[AttributeMap]] is a statistics container for attributes. Provides API to register attributes,
+ * update statistics for individual attribute and write all attributes into a file.
+ */
+private[spark] class AttributeMap {
+  // Map of attributes, name is considered to be unique key for attribute. Column name is usually
+  // used as unique key
+  private val map: HashMap[String, Attribute[_]] = HashMap.empty
+
+  /** Return underlying map, for testing purposes only */
+  private[index] def getMap() = map
+
+  /** Register new attribute */
+  def registerAttribute(attr: Attribute[_]): AttributeMap = {
+    map += attr.name -> attr
+    this
+  }
+
+  /** Register sequence of attributes */
+  def registerAttributes(attrs: Seq[Attribute[_]]): AttributeMap = {
+    map ++= attrs.map { attr => (attr.name, attr) }
+    this
+  }
+
+  /** Update statistics for a specific key, no-op if key does not exist */
+  def updateStatistics(key: String, value: Any): Unit = {
+    if (map.contains(key)) {
+      map(key).addValue(value)
+    }
+  }
+
+  /** Return writer for this attribute map */
+  def write(path: String): Unit = {
+    val writer = new StatisticsWriter(ByteOrder.BIG_ENDIAN, map.values.toSeq)
+    writer.save(path)
+  }
+}
+
+/**
+ * Interface to create or load attribute map.
+ * When creating new attribute map returns map with predefined set of statistics.
+ */
+object AttributeMap {
+  def create(): AttributeMap =
+    new AttributeMap().registerAttributes(
+      Attribute[Long]("unix_secs", 3) ::
+      Attribute[Long]("srcip", 6) ::
+      Attribute[Long]("dstip", 6) ::
+      Attribute[Int]("srcport", 6) ::
+      Attribute[Int]("dstport", 6) ::
+      Attribute[Short]("protocol", 6) ::
+      Nil)
+
+  def read(path: String): AttributeMap = {
+    val reader = new StatisticsReader()
+    new AttributeMap().registerAttributes(reader.load(path))
+  }
+}

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/AttributeMap.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/AttributeMap.scala
@@ -91,13 +91,13 @@ private[spark] class AttributeMap {
   }
 
   /** Return writer for this attribute map */
-  def write(path: String, conf: HadoopConf): Unit = {
+  def write(path: String, conf: HadoopConf, overwrite: Boolean = false): Unit = {
     val writer = new StatisticsWriter(ByteOrder.BIG_ENDIAN, map.values.toSeq)
-    writer.save(path, conf)
+    writer.save(path, conf, overwrite)
   }
 
   def write(path: String): Unit = {
-    write(path, new HadoopConf(true))
+    write(path, new HadoopConf(true), overwrite = false)
   }
 }
 

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsPathResolver.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsPathResolver.scala
@@ -18,6 +18,8 @@ package com.github.sadikovi.spark.netflow.index
 
 import org.apache.hadoop.fs.{Path => HadoopPath}
 
+import com.github.sadikovi.spark.util.Utils
+
 /**
  * [[StatisticsPathResolver]] is a simple class to find the statistics path based on a file path.
  * Also takes into account possible root to store/read statistics. Note that root may not
@@ -41,19 +43,14 @@ case class StatisticsPathResolver(maybeRoot: Option[String]) {
    * }}}
    */
   def getStatisticsPath(filePath: String): String = {
-    // Return updated path with suffix appended
-    def withSuffix(path: HadoopPath, suffix: String): HadoopPath = {
-      path.suffix(s"${HadoopPath.SEPARATOR}${suffix}")
-    }
-
     val path = new HadoopPath(filePath)
     maybeRoot match {
       case Some(root) =>
         val rootPath = new HadoopPath(root)
-        withSuffix(HadoopPath.mergePaths(rootPath, path).getParent(),
+        Utils.withSuffix(HadoopPath.mergePaths(rootPath, path).getParent(),
           getStatisticsName(path.getName)).toString
       case None =>
-        withSuffix(path.getParent(), getStatisticsName(path.getName)).toString
+        Utils.withSuffix(path.getParent(), getStatisticsName(path.getName)).toString
     }
   }
 

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsPathResolver.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsPathResolver.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.spark.netflow.index
+
+import org.apache.hadoop.fs.{Path => HadoopPath}
+
+/**
+ * [[StatisticsPathResolver]] is a simple class to find the statistics path based on a file path.
+ * Also takes into account possible root to store/read statistics. Note that root may not
+ * necessarily exist.
+ */
+case class StatisticsPathResolver(maybeRoot: Option[String]) {
+  if (maybeRoot.isDefined) {
+    require(maybeRoot.get != null && maybeRoot.get.nonEmpty,
+      s"Root path is expected to be non-empty, got $maybeRoot")
+  }
+
+  /**
+   * Return statistics path based on root and file path.
+   * If root is not specified statistics file is stored side-by-side with the original file,
+   * otherwise, directory structure is replicated starting with root:
+   * {{{
+   *    val path = "/a/b/c/file"
+   *    val root = "/x/y/z"
+   *    // then statistics file will stored:
+   *    val stats = "/x/y/z/a/b/c/.statistics-file"
+   * }}}
+   */
+  def getStatisticsPath(filePath: String): String = {
+    // Return updated path with suffix appended
+    def withSuffix(path: HadoopPath, suffix: String): HadoopPath = {
+      path.suffix(s"${HadoopPath.SEPARATOR}${suffix}")
+    }
+
+    val path = new HadoopPath(filePath)
+    maybeRoot match {
+      case Some(root) =>
+        val rootPath = new HadoopPath(root)
+        withSuffix(HadoopPath.mergePaths(rootPath, path).getParent(),
+          getStatisticsName(path.getName)).toString
+      case None =>
+        withSuffix(path.getParent(), getStatisticsName(path.getName)).toString
+    }
+  }
+
+  /** Return statistics name based on original file name */
+  private def getStatisticsName(fileName: String): String = s".statistics-$fileName"
+}

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsPathResolver.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsPathResolver.scala
@@ -16,9 +16,17 @@
 
 package com.github.sadikovi.spark.netflow.index
 
+import org.apache.hadoop.conf.{Configuration => HadoopConf}
 import org.apache.hadoop.fs.{Path => HadoopPath}
 
 import com.github.sadikovi.spark.util.Utils
+
+/**
+ * [[StatisticsPathStatus]] is a holder of the parameters for statistics file. `path` is a
+ * fully-qualified file path, either HDFS or local file system, and `exists` indicates if file for
+ * that path exists.
+ */
+case class StatisticsPathStatus(path: String, exists: Boolean)
 
 /**
  * [[StatisticsPathResolver]] is a simple class to find the statistics path based on a file path.
@@ -52,6 +60,15 @@ case class StatisticsPathResolver(maybeRoot: Option[String]) {
       case None =>
         Utils.withSuffix(path.getParent(), getStatisticsName(path.getName)).toString
     }
+  }
+
+  /** Return statistics path status for a provided root file path */
+  def getStatisticsPathStatus(
+      filePath: String,
+      conf: HadoopConf = new HadoopConf(true)): StatisticsPathStatus = {
+    val path = new HadoopPath(getStatisticsPath(filePath))
+    val fs = path.getFileSystem(conf)
+    StatisticsPathStatus(path.toString, fs.exists(path))
   }
 
   /** Return statistics name based on original file name */

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsReader.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsReader.scala
@@ -140,9 +140,9 @@ private[spark] class StatisticsReader {
   }
 
   /** Load provided path and return sequence of attributes */
-  def load(path: String): Seq[Attribute[_]] = {
+  def load(path: String, conf: HadoopConf = new HadoopConf(true)): Seq[Attribute[_]] = {
     val pt = new HadoopPath(path)
-    val fs = pt.getFileSystem(new HadoopConf(true))
+    val fs = pt.getFileSystem(conf)
     val in = fs.open(pt)
     val attributes = try {
       internalLoad(in)

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsReader.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsReader.scala
@@ -30,7 +30,7 @@ import org.apache.hadoop.fs.{Path => HadoopPath}
  * parsed attributes. Note that type inference does not apply, so sequence of arbitrary attributes
  * is returned.
  */
-class StatisticsReader {
+private[spark] class StatisticsReader {
   var buffer: ByteBuf = null
 
   private def checkMagicNumbers(magic1: Short, magic2: Short): Unit = {

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsReader.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsReader.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.spark.netflow.index
+
+import java.io.InputStream
+
+import scala.collection.mutable.ArrayBuffer
+
+import io.netty.buffer.{ByteBuf, Unpooled}
+
+import org.apache.hadoop.conf.{Configuration => HadoopConf}
+import org.apache.hadoop.fs.{Path => HadoopPath}
+
+/**
+ * [[StatisticsReader]] reads bytes from file provided and converts them into sequence of
+ * parsed attributes. Note that type inference does not apply, so sequence of arbitrary attributes
+ * is returned.
+ */
+class StatisticsReader {
+  var buffer: ByteBuf = null
+
+  private def checkMagicNumbers(magic1: Short, magic2: Short): Unit = {
+    require(magic1 == StatisticsUtils.MAGIC_1 && magic2 == StatisticsUtils.MAGIC_2,
+      "Wrong magic number")
+  }
+
+  /** Verify that buffer bytes are correct */
+  private def verify(buffer: ByteBuf): Unit = {
+    val magic1 = buffer.readUnsignedByte()
+    val magic2 = buffer.readUnsignedByte()
+    checkMagicNumbers(magic1, magic2)
+  }
+
+  private[index] def getAttributeParams(buffer: ByteBuf): (Byte, Class[_], Boolean, String) = {
+    verify(buffer)
+    val flags = buffer.readByte()
+    val klass = StatisticsUtils.getClassTag(buffer.readByte())
+    val hasNull = buffer.readBoolean()
+    val name = StatisticsUtils.readValue(buffer, classOf[String]).asInstanceOf[String]
+
+    (flags, klass, hasNull, name)
+  }
+
+  /** Read property, and return type of property, class of values, and temporary buffer */
+  private[index] def readProperty(buffer: ByteBuf, hasNull: Boolean): (Byte, Iterator[Any]) = {
+    // Read property header
+    val tpe = buffer.readByte()
+    val classBytes = buffer.readByte()
+    var size = buffer.readInt()
+    val klass = StatisticsUtils.getClassTag(classBytes)
+    // Temporary cache for values
+    val temp = new ArrayBuffer[Any]()
+    // Read values sequentially
+    while (size > 0) {
+      if (hasNull) {
+        val isNullByte = buffer.readBoolean()
+        if (isNullByte) {
+          temp.append(null)
+        } else {
+          temp.append(StatisticsUtils.readValue(buffer, klass))
+        }
+      } else {
+        temp.append(StatisticsUtils.readValue(buffer, klass))
+      }
+      size -= 1
+    }
+
+    (tpe, temp.toIterator)
+  }
+
+  private[index] def getAttribute(buffer: ByteBuf): Attribute[_<:Any] = {
+    val params = getAttributeParams(buffer)
+    val flags = params._1
+    val klass = params._2
+    val hasNull = params._3
+    val name = params._4
+
+    val attr = Attribute(name, flags, klass)
+    // We cannot use `containsNull` when reading property, because it will account for min/max,
+    // which are null for empty attribute
+    attr.setNull(hasNull)
+    for (anyTpe <- 0 until attr.numStatistics()) {
+      val properties = readProperty(buffer, hasNull)
+      val tpe = properties._1
+      val iter = properties._2
+      attr.setStatistics(tpe, iter)
+    }
+
+    attr
+  }
+
+  /** Internal loading method based on input stream */
+  private[index] def internalLoad(in: InputStream): Seq[Attribute[_]] = {
+    // Read file header and verify magic numbers, and resolve byte order
+    val array = new Array[Byte](StatisticsUtils.INITIAL_STATE_SIZE)
+    in.read(array)
+    buffer = Unpooled.wrappedBuffer(array)
+    verify(buffer)
+    val endianness = StatisticsUtils.getEndianness(buffer.readByte())
+    buffer.release(buffer.refCnt)
+
+    // Fill up buffer, note we do not know the size of input stream in general case, e.g. if stream
+    // is compressed, therefore fill buffer in chunks of its own capacity
+    buffer = Unpooled.buffer().order(endianness)
+    while (in.available > 0) {
+      buffer.writeBytes(in, buffer.capacity)
+    }
+
+    // In order to know how many attributes we have in input stream, we use a trick that writer
+    // index of byte buffer points to the last written byte, which is different from its capacity.
+    // When everything is okay and file is written correctly, then reader index should be equal
+    // writer index by the end of parsing
+    val attributesBuffer = new ArrayBuffer[Attribute[_]]()
+    while (buffer.readerIndex < buffer.writerIndex) {
+      attributesBuffer.append(getAttribute(buffer))
+    }
+
+    attributesBuffer.toSeq
+  }
+
+  /** Release underlying byte buffer */
+  private def close(): Unit = try {
+    buffer.release(buffer.refCnt)
+  } finally {
+    buffer = null
+  }
+
+  /** Load provided path and return sequence of attributes */
+  def load(path: String): Seq[Attribute[_]] = {
+    val pt = new HadoopPath(path)
+    val fs = pt.getFileSystem(new HadoopConf(true))
+    val in = fs.open(pt)
+    val attributes = try {
+      internalLoad(in)
+    } finally {
+      close()
+      in.close()
+    }
+    attributes
+  }
+}

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsUtils.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsUtils.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.spark.netflow.index
+
+import java.nio.ByteOrder
+
+import io.netty.buffer.ByteBuf
+
+object StatisticsUtils {
+  // Magic numbers as first bytes in a file
+  val MAGIC_1: Short = 0xCA
+  val MAGIC_2: Short = 0x11
+
+  // Size of initial state in bytes
+  val INITIAL_STATE_SIZE: Int = 3
+
+  // Type indices of internal containers for attribute
+  val TYPE_COUNT: Byte = 1
+  val TYPE_MINMAX: Byte = 2
+  val TYPE_SET: Byte = 4
+
+  /** Convert endianness into byte */
+  def getEndiannessIndex(endianness: ByteOrder): Byte = {
+    if (endianness == ByteOrder.LITTLE_ENDIAN) 1 else 2
+  }
+
+  /** Convert byte into endianness */
+  def getEndianness(index: Byte): ByteOrder = {
+    if (index == 1) ByteOrder.LITTLE_ENDIAN else ByteOrder.BIG_ENDIAN
+  }
+
+  /** Write bytes and verify number of bytes written */
+  def withBytes(buffer: ByteBuf, numBytes: Int)(func: ByteBuf => Unit): Unit = {
+    val begin = buffer.writerIndex
+    val result = func(buffer)
+    val end = buffer.writerIndex
+    require(end - begin == numBytes,
+      s"Written ${end - begin} bytes does not equal to $numBytes bytes")
+  }
+
+  /** Get number of bytes for class, only supports numeric classes for now */
+  def getBytes(klass: Class[_]): Byte = {
+    if (klass == classOf[Byte]) {
+      return 1
+    } else if (klass == classOf[Short]) {
+      return 2
+    } else if (klass == classOf[Int]) {
+      return 4
+    } else if (klass == classOf[Long]) {
+      return 8
+    } else {
+      sys.error(s"Unsuppored type $klass")
+    }
+  }
+
+  /** Get class based on number of bytes */
+  def getClassTag(numBytes: Byte): Class[_] = numBytes match {
+    case 1 => classOf[Byte]
+    case 2 => classOf[Short]
+    case 4 => classOf[Int]
+    case 8 => classOf[Long]
+    case other => sys.error(s"Unsupported number of bytes $numBytes")
+  }
+
+  /** Write value based on a provided class */
+  def writeValue(buffer: ByteBuf, value: Any, klass: Class[_]): Unit = {
+    if (klass == classOf[Byte]) {
+      buffer.writeByte(value.asInstanceOf[Byte].toInt)
+    } else if (klass == classOf[Short]) {
+      buffer.writeShort(value.asInstanceOf[Short].toInt)
+    } else if (klass == classOf[Int]) {
+      buffer.writeInt(value.asInstanceOf[Int])
+    } else if (klass == classOf[Long]) {
+      buffer.writeLong(value.asInstanceOf[Long])
+    } else {
+      sys.error(s"Unsupported field type $klass")
+    }
+  }
+
+  /** Read value based on provided class */
+  def readValue(buffer: ByteBuf, klass: Class[_]): Any = {
+    if (klass == classOf[Byte]) {
+      buffer.readByte()
+    } else if (klass == classOf[Short]) {
+      buffer.readShort()
+    } else if (klass == classOf[Int]) {
+      buffer.readInt()
+    } else if (klass == classOf[Long]) {
+      buffer.readLong()
+    } else {
+      sys.error(s"Unsupported field type $klass")
+    }
+  }
+}

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsUtils.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsUtils.scala
@@ -121,4 +121,27 @@ object StatisticsUtils {
       sys.error(s"Unsupported field type $klass")
     }
   }
+
+  /** Convert java class to closely matched scala class, otherwise return itself */
+  def javaToScala(klass: Class[_]): Class[_] = {
+    if (klass == classOf[java.lang.Byte]) {
+      classOf[Byte]
+    } else if (klass == classOf[java.lang.Short]) {
+      classOf[Short]
+    } else if (klass == classOf[java.lang.Integer]) {
+      classOf[Int]
+    } else if (klass == classOf[java.lang.Long]) {
+      classOf[Long]
+    } else {
+      klass
+    }
+  }
+
+  /**
+   * Compare classes and return true, if both classes match either directly or with conversion,
+   * otherwise false
+   */
+  def softCompare(klass1: Class[_], klass2: Class[_]): Boolean = {
+    klass1 == klass2 || javaToScala(klass1) == javaToScala(klass2)
+  }
 }

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsWriter.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsWriter.scala
@@ -125,10 +125,13 @@ private[spark] class StatisticsWriter(
   }
 
   /** Save provided attributes into a file */
-  def save(path: String, conf: HadoopConf = new HadoopConf(true)): Unit = {
+  def save(
+      path: String,
+      conf: HadoopConf = new HadoopConf(true),
+      overwrite: Boolean = false): Unit = {
     val pt = new HadoopPath(path)
     val fs = pt.getFileSystem(conf)
-    val out = fs.create(pt, false)
+    val out = fs.create(pt, overwrite)
     internalSave(out)
     out.close()
     close()

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsWriter.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsWriter.scala
@@ -125,9 +125,9 @@ private[spark] class StatisticsWriter(
   }
 
   /** Save provided attributes into a file */
-  def save(path: String): Unit = {
+  def save(path: String, conf: HadoopConf = new HadoopConf(true)): Unit = {
     val pt = new HadoopPath(path)
-    val fs = pt.getFileSystem(new HadoopConf(true))
+    val fs = pt.getFileSystem(conf)
     val out = fs.create(pt, false)
     internalSave(out)
     out.close()

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsWriter.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsWriter.scala
@@ -32,7 +32,9 @@ import org.apache.hadoop.fs.{Path => HadoopPath}
  * types of attributes are supported. `OutputStream` is handled and closed automatically, with
  * underlying byte buffer.
  */
-class StatisticsWriter(private val endianness: ByteOrder, private val attrs: Seq[Attribute[_]]) {
+private[spark] class StatisticsWriter(
+    private val endianness: ByteOrder,
+    private val attrs: Seq[Attribute[_]]) {
   var buffer: ByteBuf = Unpooled.buffer().order(endianness)
   init()
 

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsWriter.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsWriter.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.spark.netflow.index
+
+import java.io.OutputStream
+import java.nio.ByteOrder
+import java.nio.charset.Charset
+
+import scala.collection.GenTraversableOnce
+import scala.collection.JavaConverters._
+
+import io.netty.buffer.{ByteBuf, Unpooled}
+
+import org.apache.hadoop.conf.{Configuration => HadoopConf}
+import org.apache.hadoop.fs.{Path => HadoopPath}
+
+/**
+ * [[StatisticsWriter]] writes sequence of attributes into a file provided. Note that only numeric
+ * types of attributes are supported. `OutputStream` is handled and closed automatically, with
+ * underlying byte buffer.
+ */
+class StatisticsWriter(private val endianness: ByteOrder, private val attrs: Seq[Attribute[_]]) {
+  var buffer: ByteBuf = Unpooled.buffer().order(endianness)
+  init()
+
+  /** Write initial state: magic numbers, endianness */
+  private def init(): Unit = {
+    StatisticsUtils.withBytes(buffer, StatisticsUtils.INITIAL_STATE_SIZE) { buf =>
+      buf.writeByte(StatisticsUtils.MAGIC_1)
+      buf.writeByte(StatisticsUtils.MAGIC_2)
+      buf.writeByte(StatisticsUtils.getEndiannessIndex(endianness))
+    }
+  }
+
+  /** Write attribute header (flags, name, etc). Exposed to a package for testing purposes */
+  private[index] def writeAttributeHeader(flags: Byte, key: String, charset: Charset): Unit = {
+    buffer.writeByte(StatisticsUtils.MAGIC_1)
+    buffer.writeByte(StatisticsUtils.MAGIC_2)
+    buffer.writeByte(flags)
+    // Bytes of the key based on charset
+    val charBytes = key.getBytes(charset)
+    buffer.writeInt(charBytes.length)
+    buffer.writeBytes(charBytes)
+  }
+
+  /** Generic write method for arbitrary sequence of elements */
+  private def writeElements(
+      tpe: Byte, klass: Class[_], size: Int, elems: GenTraversableOnce[_]): Unit = {
+    buffer.writeByte(tpe)
+    buffer.writeByte(StatisticsUtils.getBytes(klass))
+    buffer.writeInt(size)
+    val iter = elems.toIterator
+    while (iter.hasNext) {
+      val elem = iter.next
+      require(elem != null, s"Cannot write value $elem")
+      StatisticsUtils.writeValue(buffer, elem, klass)
+    }
+  }
+
+  private def writeElements(tpe: Byte, klass: Class[_], elems: GenTraversableOnce[_]): Unit = {
+    writeElements(tpe, klass, elems.size, elems)
+  }
+
+  /** Internal method to write single attribute. Exposed to a package for testing purposes */
+  private[index] def writeAttribute(attr: Attribute[_]): Unit = {
+    // Currently we force ASCII encoding for an attribute name
+    writeAttributeHeader(attr.flags, attr.name, Charset.forName("ASCII"))
+    // Attribute "count" parameter is always of long type regardless of runtime class
+    attr.getCount() match {
+      case Some(count) =>
+        writeElements(StatisticsUtils.TYPE_COUNT, classOf[Long], Seq[Long](count))
+      case None => // do nothing
+    }
+
+    attr.getMinMax() match {
+      case Some((min, max)) =>
+        writeElements(StatisticsUtils.TYPE_MINMAX, attr.getClassTag(), Seq(min, max))
+      case None => // do nothing
+    }
+
+    attr.getSet() match {
+      case Some(set) =>
+        writeElements(StatisticsUtils.TYPE_SET, attr.getClassTag(), set.size(),
+          set.iterator.asScala)
+      case None => // do nothing
+    }
+  }
+
+  /** Internal save method, write each attribute and transfer bytes into output stream */
+  private def internalSave(out: OutputStream): Unit = {
+    for (attr <- attrs) {
+      writeAttribute(attr)
+    }
+    buffer.getBytes(0, out, buffer.writerIndex)
+  }
+
+  /** Close underlying buffer */
+  private def close(): Unit = try {
+    buffer.release(buffer.refCnt)
+  } finally {
+    buffer = null
+  }
+
+  /** Save provided attributes into a file */
+  def save(path: String): Unit = {
+    val pt = new HadoopPath(path)
+    val fs = pt.getFileSystem(new HadoopConf(true))
+    val out = fs.create(pt, false)
+    internalSave(out)
+    out.close()
+    close()
+  }
+}

--- a/src/main/scala/com/github/sadikovi/spark/netflow/sources/NetFlowFileStatus.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/sources/NetFlowFileStatus.scala
@@ -16,6 +16,8 @@
 
 package com.github.sadikovi.spark.netflow.sources
 
+import com.github.sadikovi.spark.netflow.index.StatisticsPathStatus
+
 /**
  * NetFlow file status that describes file to process. Contains expected version of a file,
  * absolute resolved path to the file, and it's length, buffer size for a particular file
@@ -24,12 +26,12 @@ package com.github.sadikovi.spark.netflow.sources
  * @param path absolute file path, in case of HDFS includes host and port
  * @param length file size in bytes
  * @param bufferSize buffer size (when file stream is compressed) in bytes
- * @param statisticsPath absolute file path to the statistics file
+ * @param statisticsPathStatus statistics path status, includes file path and exists flag
  */
 private[spark] case class NetFlowFileStatus(
   version: Short,
   path: String,
   length: Long,
   bufferSize: Int,
-  statisticsPath: Option[String]
+  statisticsPathStatus: Option[StatisticsPathStatus]
 )

--- a/src/main/scala/com/github/sadikovi/spark/netflow/sources/NetFlowFileStatus.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/sources/NetFlowFileStatus.scala
@@ -24,10 +24,12 @@ package com.github.sadikovi.spark.netflow.sources
  * @param path absolute file path, in case of HDFS includes host and port
  * @param length file size in bytes
  * @param bufferSize buffer size (when file stream is compressed) in bytes
+ * @param statisticsPath absolute file path to the statistics file
  */
 private[spark] case class NetFlowFileStatus(
   version: Short,
   path: String,
   length: Long,
-  bufferSize: Int
+  bufferSize: Int,
+  statisticsPath: Option[String]
 )

--- a/src/main/scala/com/github/sadikovi/spark/netflow/sources/ResolvedInterface.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/sources/ResolvedInterface.scala
@@ -42,10 +42,7 @@ private[spark] object InternalType {
   val LONG = classOf[java.lang.Long]
 }
 
-/**
- * Abstract interface for NetFlow version.
- *
- */
+/** Abstract interface for NetFlow version */
 abstract class ResolvedInterface {
 
   /** Interface columns, sequence has to contain at least one column */
@@ -79,6 +76,9 @@ abstract class ResolvedInterface {
 
   /** Get first [[MappedColumn]] as `Option`. */
   def getFirstColumnOption(): Option[MappedColumn] = columns.headOption
+
+  /** Get columns with enabled statistics */
+  def getStatisticsColumns(): Seq[MappedColumn] = columns.filter { _.collectStatistics }
 
   /** Get [[MappedColumn]] for a specified column name. Fail, if column name is not present. */
   def getColumn(columnName: String): MappedColumn = {

--- a/src/main/scala/com/github/sadikovi/spark/netflow/sources/statistics.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/sources/statistics.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.spark.netflow.sources
+
+import org.apache.hadoop.fs.{Path => HadoopPath}
+
+/**
+ * [[StatisticsPathResolver]] is a simple class to find the statistics path based on a file path.
+ * Also takes into account possible root to store/read statistics. Note that root may not
+ * necessarily exist.
+ */
+case class StatisticsPathResolver(maybeRoot: Option[String]) {
+  if (maybeRoot.isDefined) {
+    require(maybeRoot.get != null && maybeRoot.get.nonEmpty,
+      s"Root path is expected to be non-empty, got $maybeRoot")
+  }
+
+  /**
+   * Return statistics path based on root and file path.
+   * If root is not specified statistics file is stored side-by-side with the original file,
+   * otherwise, directory structure is replicated starting with root:
+   * {{{
+   *    val path = "/a/b/c/file"
+   *    val root = "/x/y/z"
+   *    // then statistics file will stored:
+   *    val stats = "/x/y/z/a/b/c/.statistics-file"
+   * }}}
+   */
+  def getStatisticsPath(filePath: String): String = {
+    // Return updated path with suffix appended
+    def withSuffix(path: HadoopPath, suffix: String): HadoopPath = {
+      path.suffix(s"${HadoopPath.SEPARATOR}${suffix}")
+    }
+
+    val path = new HadoopPath(filePath)
+    maybeRoot match {
+      case Some(root) =>
+        val rootPath = new HadoopPath(root)
+        withSuffix(HadoopPath.mergePaths(rootPath, path).getParent(),
+          getStatisticsName(path.getName)).toString
+      case None =>
+        withSuffix(path.getParent(), getStatisticsName(path.getName)).toString
+    }
+  }
+
+  /** Return statistics name based on original file name */
+  private def getStatisticsName(fileName: String): String = s".statistics-$fileName"
+}

--- a/src/main/scala/com/github/sadikovi/spark/netflow/sources/statistics.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/sources/statistics.scala
@@ -16,6 +16,10 @@
 
 package com.github.sadikovi.spark.netflow.sources
 
+import java.util.{HashSet => JHashSet}
+
+import scala.reflect.ClassTag
+
 import org.apache.hadoop.fs.{Path => HadoopPath}
 
 /**
@@ -59,4 +63,92 @@ case class StatisticsPathResolver(maybeRoot: Option[String]) {
 
   /** Return statistics name based on original file name */
   private def getStatisticsName(fileName: String): String = s".statistics-$fileName"
+}
+
+/**
+ * [[Attribute]] interface to collect and check statistics. Included support of different
+ * combinations of collected parameters: count, min/max, and set of values through bit vector. Here
+ * are some common flags: 7 - enable all parameters, 1 - enable count, 6 - enable min/max and set.
+ * In order to create attribute comparison function is required similar the `lt` function used in
+ * `sortWith` method. Name must unique to the attribute.
+ */
+case class Attribute[T](
+    name: String,
+    lt: (T, T) => Boolean, flags: Byte)(implicit tag: ClassTag[T]) {
+  private var count: Long = if (isCountEnabled) 0 else Long.MinValue
+  private var min: T = _
+  private var max: T = _
+  private var set: JHashSet[T] = if (isSetEnabled) new JHashSet() else null
+
+  /** Add value to the attribute, it automatically checks all available modes */
+  def addValue(value: T): Unit = {
+    if (isCountEnabled) {
+      count += 1
+    }
+
+    if (isMinMaxEnabled) {
+      if (min == null || !lt(min, value)) {
+        min = value
+      }
+
+      if (max == null || lt(max, value)) {
+        max = value
+      }
+    }
+
+    if (isSetEnabled) {
+      set.add(value)
+    }
+  }
+
+  private def isEnabled(flag: Byte): Boolean = {
+    (flags & flag) == flag
+  }
+
+  /** Check if count is collected by this attribute */
+  def isCountEnabled(): Boolean = isEnabled(1)
+
+  /** Check if min/max is collected by this attribute */
+  def isMinMaxEnabled(): Boolean = isEnabled(2)
+
+  /** Check if set is collected by this attribute */
+  def isSetEnabled(): Boolean = isEnabled(4)
+
+  /** Get count, if mode is enabled, otherwise None */
+  def getCount(): Option[Long] = {
+    if (isCountEnabled) Some(count) else None
+  }
+
+  /** Check if value is in min-max range, if mode is enabled, otherwise None */
+  def containsInRange(value: T): Option[Boolean] = {
+    if (isMinMaxEnabled) Some(!lt(value, min) && !lt(max, value)) else None
+  }
+
+  /** Check if value is in set, if mode is enabled, otherwise None */
+  def containsInSet(value: T): Option[Boolean] = {
+    if (isSetEnabled) Some(set.contains(value)) else None
+  }
+
+  /** Update count with value */
+  private[sources] def setCount(value: Long): Unit = {
+    require(isCountEnabled, s"Count mode is disabled, bit flags: $flags")
+    count = value
+  }
+
+  /** Update min/max directly with values */
+  private[sources] def setMinMax(minValue: T, maxValue: T): Unit = {
+    require(isMinMaxEnabled, s"Min-max mode is disabled, bit flags: $flags")
+    min = minValue
+    max = maxValue
+  }
+
+  /** Update set directly with value */
+  private[sources] def setSet(setValue: JHashSet[T]): Unit = {
+    require(isSetEnabled, s"Set mode is disabled, bit flags: $flags")
+    set = setValue
+  }
+
+  override def toString(): String = {
+    s"${getClass().getCanonicalName}, name: $name, bit flags: $flags"
+  }
 }

--- a/src/main/scala/com/github/sadikovi/spark/netflow/version5/DefaultProvider.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/version5/DefaultProvider.scala
@@ -28,12 +28,12 @@ class DefaultProvider extends NetFlowProvider {
 /** NetFlow interface for version 5. */
 private class InterfaceV5 extends ResolvedInterface {
   override protected val columns: Seq[MappedColumn] = Seq(
-    MappedColumn("unix_secs", NetFlowV5.FIELD_UNIX_SECS, false, None),
+    MappedColumn("unix_secs", NetFlowV5.FIELD_UNIX_SECS, true, None),
     MappedColumn("unix_nsecs", NetFlowV5.FIELD_UNIX_NSECS, false, None),
     MappedColumn("sysuptime", NetFlowV5.FIELD_SYSUPTIME, false, None),
     MappedColumn("exaddr", NetFlowV5.FIELD_EXADDR, false, Some(IPv4ConvertFunction())),
-    MappedColumn("srcip", NetFlowV5.FIELD_SRCADDR, false, Some(IPv4ConvertFunction())),
-    MappedColumn("dstip", NetFlowV5.FIELD_DSTADDR, false, Some(IPv4ConvertFunction())),
+    MappedColumn("srcip", NetFlowV5.FIELD_SRCADDR, true, Some(IPv4ConvertFunction())),
+    MappedColumn("dstip", NetFlowV5.FIELD_DSTADDR, true, Some(IPv4ConvertFunction())),
     MappedColumn("nexthop", NetFlowV5.FIELD_NEXTHOP, false, Some(IPv4ConvertFunction())),
     MappedColumn("input", NetFlowV5.FIELD_INPUT, false, None),
     MappedColumn("output", NetFlowV5.FIELD_OUTPUT, false, None),
@@ -41,9 +41,9 @@ private class InterfaceV5 extends ResolvedInterface {
     MappedColumn("octets", NetFlowV5.FIELD_DOCTETS, false, None),
     MappedColumn("first_flow", NetFlowV5.FIELD_FIRST, false, None),
     MappedColumn("last_flow", NetFlowV5.FIELD_LAST, false, None),
-    MappedColumn("srcport", NetFlowV5.FIELD_SRCPORT, false, None),
-    MappedColumn("dstport", NetFlowV5.FIELD_DSTPORT, false, None),
-    MappedColumn("protocol", NetFlowV5.FIELD_PROT, false, Some(ProtocolConvertFunction())),
+    MappedColumn("srcport", NetFlowV5.FIELD_SRCPORT, true, None),
+    MappedColumn("dstport", NetFlowV5.FIELD_DSTPORT, true, None),
+    MappedColumn("protocol", NetFlowV5.FIELD_PROT, true, Some(ProtocolConvertFunction())),
     MappedColumn("tos", NetFlowV5.FIELD_TOS, false, None),
     MappedColumn("tcp_flags", NetFlowV5.FIELD_TCP_FLAGS, false, None),
     MappedColumn("engine_type", NetFlowV5.FIELD_ENGINE_TYPE, false, None),

--- a/src/main/scala/com/github/sadikovi/spark/netflow/version7/DefaultProvider.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/version7/DefaultProvider.scala
@@ -28,12 +28,12 @@ class DefaultProvider extends NetFlowProvider {
 /** NetFlow interface for version 7. */
 private class InterfaceV7 extends ResolvedInterface {
   override protected val columns: Seq[MappedColumn] = Seq(
-    MappedColumn("unix_secs", NetFlowV7.FIELD_UNIX_SECS, false, None),
+    MappedColumn("unix_secs", NetFlowV7.FIELD_UNIX_SECS, true, None),
     MappedColumn("unix_nsecs", NetFlowV7.FIELD_UNIX_NSECS, false, None),
     MappedColumn("sysuptime", NetFlowV7.FIELD_SYSUPTIME, false, None),
     MappedColumn("exaddr", NetFlowV7.FIELD_EXADDR, false, Some(IPv4ConvertFunction())),
-    MappedColumn("srcip", NetFlowV7.FIELD_SRCADDR, false, Some(IPv4ConvertFunction())),
-    MappedColumn("dstip", NetFlowV7.FIELD_DSTADDR, false, Some(IPv4ConvertFunction())),
+    MappedColumn("srcip", NetFlowV7.FIELD_SRCADDR, true, Some(IPv4ConvertFunction())),
+    MappedColumn("dstip", NetFlowV7.FIELD_DSTADDR, true, Some(IPv4ConvertFunction())),
     MappedColumn("nexthop", NetFlowV7.FIELD_NEXTHOP, false, Some(IPv4ConvertFunction())),
     MappedColumn("input", NetFlowV7.FIELD_INPUT, false, None),
     MappedColumn("output", NetFlowV7.FIELD_OUTPUT, false, None),
@@ -41,9 +41,9 @@ private class InterfaceV7 extends ResolvedInterface {
     MappedColumn("octets", NetFlowV7.FIELD_DOCTETS, false, None),
     MappedColumn("first_flow", NetFlowV7.FIELD_FIRST, false, None),
     MappedColumn("last_flow", NetFlowV7.FIELD_LAST, false, None),
-    MappedColumn("srcport", NetFlowV7.FIELD_SRCPORT, false, None),
-    MappedColumn("dstport", NetFlowV7.FIELD_DSTPORT, false, None),
-    MappedColumn("protocol", NetFlowV7.FIELD_PROT, false, Some(ProtocolConvertFunction())),
+    MappedColumn("srcport", NetFlowV7.FIELD_SRCPORT, true, None),
+    MappedColumn("dstport", NetFlowV7.FIELD_DSTPORT, true, None),
+    MappedColumn("protocol", NetFlowV7.FIELD_PROT, true, Some(ProtocolConvertFunction())),
     MappedColumn("tos", NetFlowV7.FIELD_TOS, false, None),
     MappedColumn("tcp_flags", NetFlowV7.FIELD_TCP_FLAGS, false, None),
     MappedColumn("flags", NetFlowV7.FIELD_FLAGS, false, None),

--- a/src/main/scala/com/github/sadikovi/spark/rdd/FileRDD.scala
+++ b/src/main/scala/com/github/sadikovi/spark/rdd/FileRDD.scala
@@ -30,7 +30,7 @@ import com.github.sadikovi.spark.util.SerializableConfiguration
  * configuration as `SparkContext.hadoopConfiguration` that will be serialized to send to all
  * workers.
  */
-private[spark] abstract class FileRDD[T: ClassTag](
+private[spark] abstract class FileRDD[T : ClassTag](
     @transient sc: SparkContext,
     @transient deps: Seq[Dependency[_]])
     (implicit _conf: Configuration = sc.hadoopConfiguration) extends RDD[T](sc, deps) {

--- a/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
+++ b/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
@@ -158,7 +158,7 @@ private[spark] class NetFlowFileRDD[T<:SQLRow : ClassTag] (
               // then continue to extract records. For empty files, Spark will try to write
               // statistics twice, because of double invocation of `hasNext`, we overwrite old file
               if (!rawIterator.hasNext) {
-                logWarning(s"Ready to write statistics for path: ${statStatus.path}")
+                logInfo(s"Ready to write statistics for path: ${statStatus.path}")
                 attributes.write(statStatus.path, conf, overwrite = true)
               }
               rawIterator.hasNext
@@ -180,7 +180,7 @@ private[spark] class NetFlowFileRDD[T<:SQLRow : ClassTag] (
           rawIterator
         }
       } else {
-        logDebug(s"Statistics are disabled, skip writing")
+        logDebug("Statistics are disabled, skip writing")
         rawIterator
       }
 

--- a/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
+++ b/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
@@ -51,8 +51,8 @@ private[spark] class NetFlowFilePartition[T<:NetFlowFileStatus: ClassTag] (
 }
 
 /**
- * `NetFlowFileRDD` is designed to process NetFlow file of specific version and return iterator of
- * SQL rows back. Used internally solely for the purpose of datasource API. We assume that we
+ * [[NetFlowFileRDD]] is designed to process NetFlow file of specific version and return iterator
+ * of SQL rows back. Used internally solely for the purpose of datasource API. We assume that we
  * process files of the same version, and prune common fields. `NetFlowFileRDD` operates on already
  * resolved columns, the same applies to filters.
  */

--- a/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
+++ b/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
@@ -180,12 +180,12 @@ private[spark] class NetFlowFileRDD[T<:SQLRow : ClassTag] (
           rawIterator
         }
       } else {
-        logDebug(s"Conditions are not met for storing statistics, skip writing")
+        logDebug(s"Statistics are disabled, skip writing")
         rawIterator
       }
 
       // Conversion iterator, applies defined modification for convertable fields
-      val conversionsIterator = if (applyConversion) {
+      val withConversionsIterator = if (applyConversion) {
         // For each field we check if possible conversion is available. If it is we apply direct
         // conversion, otherwise return unchanged value. Note that this should be in sync with
         // `applyConversion` and updated schema from `ResolvedInterface`.
@@ -202,7 +202,7 @@ private[spark] class NetFlowFileRDD[T<:SQLRow : ClassTag] (
         writableIterator
       }
 
-      buffer = buffer ++ conversionsIterator
+      buffer = buffer ++ withConversionsIterator
     }
 
     new Iterator[SQLRow] {

--- a/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
+++ b/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
@@ -34,7 +34,7 @@ import com.github.sadikovi.netflowlib.predicate.Operators.FilterPredicate
 import com.github.sadikovi.spark.netflow.sources._
 
 /** NetFlowFilePartition to hold sequence of file paths */
-private[spark] class NetFlowFilePartition[T<:NetFlowFileStatus: ClassTag] (
+private[spark] class NetFlowFilePartition[T<:NetFlowFileStatus : ClassTag] (
     var rddId: Long,
     var slice: Int,
     var values: Seq[T]) extends Partition with Serializable {
@@ -56,7 +56,7 @@ private[spark] class NetFlowFilePartition[T<:NetFlowFileStatus: ClassTag] (
  * process files of the same version, and prune common fields. `NetFlowFileRDD` operates on already
  * resolved columns, the same applies to filters.
  */
-private[spark] class NetFlowFileRDD[T<:SQLRow: ClassTag] (
+private[spark] class NetFlowFileRDD[T<:SQLRow : ClassTag] (
     @transient sc: SparkContext,
     @transient data: Seq[NetFlowFileStatus],
     val partitionMode: PartitionMode,

--- a/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
+++ b/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
@@ -154,9 +154,12 @@ private[spark] class NetFlowFileRDD[T<:SQLRow : ClassTag] (
             override def hasNext: Boolean = {
               // If raw iterator does not have any elements we assume that it is EOF and write
               // statistics into a file
+              // There is a feature in Spark when iterator is invoked once to get `hasNext`, and
+              // then continue to extract records. For empty files, Spark will try to write
+              // statistics twice, because of double invocation of `hasNext`, we overwrite old file
               if (!rawIterator.hasNext) {
                 logWarning(s"Ready to write statistics for path: ${statStatus.path}")
-                attributes.write(statStatus.path, conf)
+                attributes.write(statStatus.path, conf, overwrite = true)
               }
               rawIterator.hasNext
             }

--- a/src/test/scala/com/github/sadikovi/spark/netflow/NetFlowFiltersSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/NetFlowFiltersSuite.scala
@@ -16,13 +16,14 @@
 
 package com.github.sadikovi.spark.netflow
 
-import java.util.HashSet
+import java.util.{HashSet => JHashSet}
 
 import org.apache.spark.sql.sources._
 
 import com.github.sadikovi.netflowlib.predicate.FilterApi
 import com.github.sadikovi.netflowlib.predicate.Columns.Column
-import com.github.sadikovi.netflowlib.predicate.Operators.{FilterPredicate, In => IIn}
+import com.github.sadikovi.netflowlib.predicate.Operators.{FilterPredicate, In => JIn}
+import com.github.sadikovi.spark.netflow.index.{Attribute, AttributeMap}
 import com.github.sadikovi.spark.netflow.sources.NetFlowRegistry
 import com.github.sadikovi.testutil.UnitTestSpec
 
@@ -31,13 +32,28 @@ class NetFlowFiltersSuite extends UnitTestSpec {
   private val catalog = NetFlowRegistry.createInterface(
     "com.github.sadikovi.spark.netflow.sources.FakeDefaultProvider")
 
-  private def compareSimpleFilter(got: FilterPredicate, expected: FilterPredicate): Unit = {
+  // Fake attribute map with dummy columns
+  private val attributes = fakeAttributeMap()
+
+  private def fakeAttributeMap(): AttributeMap = {
+    val col2 = Attribute[Short]("col2", 6)
+    col2.addValue(4.toShort)
+    col2.addValue(6.toShort)
+    col2.addValue(8.toShort)
+    val col4 = Attribute[Long]("col4", 6)
+    col4.addValue(1L)
+    col4.addValue(5L)
+    col4.addValue(12L)
+    AttributeMap.empty.registerAttributes(col2 :: col4 :: Nil)
+  }
+
+  private def compareFilter(got: FilterPredicate, expected: FilterPredicate): Unit = {
     got.getClass() should be (expected.getClass())
     got should equal (expected)
   }
 
-  private def inFilter(column: Column, values: Array[Any]): IIn = {
-    val set = new HashSet[Any]();
+  private def inFilter(column: Column, values: Array[Any]): JIn = {
+    val set = new JHashSet[Any]();
     for (vl <- values) {
       set.add(vl)
     }
@@ -82,106 +98,106 @@ class NetFlowFiltersSuite extends UnitTestSpec {
 
   test("convert filter - EqualTo") {
     var pred = NetFlowFilters.convertFilter(EqualTo("col1", 10.toByte), catalog)
-    compareSimpleFilter(pred, FilterApi.eq(catalog.getColumn("col1").internalColumn, 10.toByte))
+    compareFilter(pred, FilterApi.eq(catalog.getColumn("col1").internalColumn, 10.toByte))
 
     pred = NetFlowFilters.convertFilter(EqualTo("col2", 11.toShort), catalog)
-    compareSimpleFilter(pred, FilterApi.eq(catalog.getColumn("col2").internalColumn, 11.toShort))
+    compareFilter(pred, FilterApi.eq(catalog.getColumn("col2").internalColumn, 11.toShort))
 
     pred = NetFlowFilters.convertFilter(EqualTo("col3", 12), catalog)
-    compareSimpleFilter(pred, FilterApi.eq(catalog.getColumn("col3").internalColumn, 12))
+    compareFilter(pred, FilterApi.eq(catalog.getColumn("col3").internalColumn, 12))
 
     pred = NetFlowFilters.convertFilter(EqualTo("col4", 14.toLong), catalog)
-    compareSimpleFilter(pred, FilterApi.eq(catalog.getColumn("col4").internalColumn, 14.toLong))
+    compareFilter(pred, FilterApi.eq(catalog.getColumn("col4").internalColumn, 14.toLong))
   }
 
   test("convert filter - GreaterThan") {
     var pred = NetFlowFilters.convertFilter(GreaterThan("col1", 10.toByte), catalog)
-    compareSimpleFilter(pred, FilterApi.gt(catalog.getColumn("col1").internalColumn, 10.toByte))
+    compareFilter(pred, FilterApi.gt(catalog.getColumn("col1").internalColumn, 10.toByte))
 
     pred = NetFlowFilters.convertFilter(GreaterThan("col2", 11.toShort), catalog)
-    compareSimpleFilter(pred, FilterApi.gt(catalog.getColumn("col2").internalColumn, 11.toShort))
+    compareFilter(pred, FilterApi.gt(catalog.getColumn("col2").internalColumn, 11.toShort))
 
     pred = NetFlowFilters.convertFilter(GreaterThan("col3", 12), catalog)
-    compareSimpleFilter(pred, FilterApi.gt(catalog.getColumn("col3").internalColumn, 12))
+    compareFilter(pred, FilterApi.gt(catalog.getColumn("col3").internalColumn, 12))
 
     pred = NetFlowFilters.convertFilter(GreaterThan("col4", 14.toLong), catalog)
-    compareSimpleFilter(pred, FilterApi.gt(catalog.getColumn("col4").internalColumn, 14.toLong))
+    compareFilter(pred, FilterApi.gt(catalog.getColumn("col4").internalColumn, 14.toLong))
   }
 
   test("convert filter - GreaterThanOrEqual") {
     var pred = NetFlowFilters.convertFilter(GreaterThanOrEqual("col1", 10.toByte), catalog)
-    compareSimpleFilter(pred, FilterApi.ge(catalog.getColumn("col1").internalColumn, 10.toByte))
+    compareFilter(pred, FilterApi.ge(catalog.getColumn("col1").internalColumn, 10.toByte))
 
     pred = NetFlowFilters.convertFilter(GreaterThanOrEqual("col2", 11.toShort), catalog)
-    compareSimpleFilter(pred, FilterApi.ge(catalog.getColumn("col2").internalColumn, 11.toShort))
+    compareFilter(pred, FilterApi.ge(catalog.getColumn("col2").internalColumn, 11.toShort))
 
     pred = NetFlowFilters.convertFilter(GreaterThanOrEqual("col3", 12), catalog)
-    compareSimpleFilter(pred, FilterApi.ge(catalog.getColumn("col3").internalColumn, 12))
+    compareFilter(pred, FilterApi.ge(catalog.getColumn("col3").internalColumn, 12))
 
     pred = NetFlowFilters.convertFilter(GreaterThanOrEqual("col4", 14.toLong), catalog)
-    compareSimpleFilter(pred, FilterApi.ge(catalog.getColumn("col4").internalColumn, 14.toLong))
+    compareFilter(pred, FilterApi.ge(catalog.getColumn("col4").internalColumn, 14.toLong))
   }
 
   test("convert filter - LessThan") {
     var pred = NetFlowFilters.convertFilter(LessThan("col1", 10.toByte), catalog)
-    compareSimpleFilter(pred, FilterApi.lt(catalog.getColumn("col1").internalColumn, 10.toByte))
+    compareFilter(pred, FilterApi.lt(catalog.getColumn("col1").internalColumn, 10.toByte))
 
     pred = NetFlowFilters.convertFilter(LessThan("col2", 11.toShort), catalog)
-    compareSimpleFilter(pred, FilterApi.lt(catalog.getColumn("col2").internalColumn, 11.toShort))
+    compareFilter(pred, FilterApi.lt(catalog.getColumn("col2").internalColumn, 11.toShort))
 
     pred = NetFlowFilters.convertFilter(LessThan("col3", 12), catalog)
-    compareSimpleFilter(pred, FilterApi.lt(catalog.getColumn("col3").internalColumn, 12))
+    compareFilter(pred, FilterApi.lt(catalog.getColumn("col3").internalColumn, 12))
 
     pred = NetFlowFilters.convertFilter(LessThan("col4", 14.toLong), catalog)
-    compareSimpleFilter(pred, FilterApi.lt(catalog.getColumn("col4").internalColumn, 14.toLong))
+    compareFilter(pred, FilterApi.lt(catalog.getColumn("col4").internalColumn, 14.toLong))
   }
 
   test("convert filter - LessThanOrEqual") {
     var pred = NetFlowFilters.convertFilter(LessThanOrEqual("col1", 10.toByte), catalog)
-    compareSimpleFilter(pred, FilterApi.le(catalog.getColumn("col1").internalColumn, 10.toByte))
+    compareFilter(pred, FilterApi.le(catalog.getColumn("col1").internalColumn, 10.toByte))
 
     pred = NetFlowFilters.convertFilter(LessThanOrEqual("col2", 11.toShort), catalog)
-    compareSimpleFilter(pred, FilterApi.le(catalog.getColumn("col2").internalColumn, 11.toShort))
+    compareFilter(pred, FilterApi.le(catalog.getColumn("col2").internalColumn, 11.toShort))
 
     pred = NetFlowFilters.convertFilter(LessThanOrEqual("col3", 12), catalog)
-    compareSimpleFilter(pred, FilterApi.le(catalog.getColumn("col3").internalColumn, 12))
+    compareFilter(pred, FilterApi.le(catalog.getColumn("col3").internalColumn, 12))
 
     pred = NetFlowFilters.convertFilter(LessThanOrEqual("col4", 14.toLong), catalog)
-    compareSimpleFilter(pred, FilterApi.le(catalog.getColumn("col4").internalColumn, 14.toLong))
+    compareFilter(pred, FilterApi.le(catalog.getColumn("col4").internalColumn, 14.toLong))
   }
 
   test("convert filter - In") {
     var values = Array[Any](1.toByte, 2.toByte, 3.toByte, 4.toByte, 5.toByte)
     var pred = NetFlowFilters.convertFilter(In("col1", values), catalog)
-    compareSimpleFilter(pred, inFilter(catalog.getColumn("col1").internalColumn, values))
+    compareFilter(pred, inFilter(catalog.getColumn("col1").internalColumn, values))
 
     values = Array[Any](1.toShort, 2.toShort, 3.toShort, 4.toShort, 5.toShort)
     pred = NetFlowFilters.convertFilter(In("col2", values), catalog)
-    compareSimpleFilter(pred, inFilter(catalog.getColumn("col2").internalColumn, values))
+    compareFilter(pred, inFilter(catalog.getColumn("col2").internalColumn, values))
 
     values = Array[Any](1, 2, 3, 4, 5)
     pred = NetFlowFilters.convertFilter(In("col3", values), catalog)
-    compareSimpleFilter(pred, inFilter(catalog.getColumn("col3").internalColumn, values))
+    compareFilter(pred, inFilter(catalog.getColumn("col3").internalColumn, values))
 
     values = Array[Any](1L, 2L, 3L, 4L, 5L)
     pred = NetFlowFilters.convertFilter(In("col4", values), catalog)
-    compareSimpleFilter(pred, inFilter(catalog.getColumn("col4").internalColumn, values))
+    compareFilter(pred, inFilter(catalog.getColumn("col4").internalColumn, values))
   }
 
-  test("fail for filter In with array of multi-values") {
+  test("fail to filter In with array of values of different types") {
     intercept[ClassCastException] {
       val values = Array[Any](1.toByte, 2.toShort, 3, 4.toLong)
       val pred = NetFlowFilters.convertFilter(In("col4", values), catalog)
-      compareSimpleFilter(pred, inFilter(catalog.getColumn("col4").internalColumn, values))
+      compareFilter(pred, inFilter(catalog.getColumn("col4").internalColumn, values))
     }
   }
 
   test("convert filter - IsNull, IsNotNull") {
     var pred = NetFlowFilters.convertFilter(IsNull("col1"), catalog)
-    compareSimpleFilter(pred, FilterApi.trivial(false))
+    compareFilter(pred, FilterApi.trivial(false))
 
     pred = NetFlowFilters.convertFilter(IsNotNull("col1"), catalog)
-    compareSimpleFilter(pred, FilterApi.trivial(true))
+    compareFilter(pred, FilterApi.trivial(true))
   }
 
   test("convert filter - And, Or, Not") {
@@ -192,15 +208,15 @@ class NetFlowFiltersSuite extends UnitTestSpec {
 
     filter = And(EqualTo("col3", 10), GreaterThan("col3", 200))
     pred = NetFlowFilters.convertFilter(filter, catalog)
-    compareSimpleFilter(pred, FilterApi.and(FilterApi.eq(col3, 10), FilterApi.gt(col3, 200)))
+    compareFilter(pred, FilterApi.and(FilterApi.eq(col3, 10), FilterApi.gt(col3, 200)))
 
     filter = And(IsNull("col3"), GreaterThan("col3", 200))
     pred = NetFlowFilters.convertFilter(filter, catalog)
-    compareSimpleFilter(pred, FilterApi.and(FilterApi.trivial(false), FilterApi.gt(col3, 200)))
+    compareFilter(pred, FilterApi.and(FilterApi.trivial(false), FilterApi.gt(col3, 200)))
 
     filter = Or(And(IsNull("col3"), GreaterThan("col3", 200)), Not(LessThan("col4", 10L)))
     pred = NetFlowFilters.convertFilter(filter, catalog)
-    compareSimpleFilter(pred,
+    compareFilter(pred,
       FilterApi.or(
         FilterApi.and(
           FilterApi.trivial(false),
@@ -215,18 +231,200 @@ class NetFlowFiltersSuite extends UnitTestSpec {
 
   test("convert unsupported filter") {
     var pred = NetFlowFilters.convertFilter(StringStartsWith("col1", "a"), catalog)
-    compareSimpleFilter(pred, FilterApi.trivial(true))
+    compareFilter(pred, FilterApi.trivial(true))
 
     pred = NetFlowFilters.convertFilter(StringEndsWith("col1", "a"), catalog)
-    compareSimpleFilter(pred, FilterApi.trivial(true))
+    compareFilter(pred, FilterApi.trivial(true))
 
     pred = NetFlowFilters.convertFilter(StringContains("col1", "a"), catalog)
-    compareSimpleFilter(pred, FilterApi.trivial(true))
+    compareFilter(pred, FilterApi.trivial(true))
   }
 
   test("unconvertable filter value") {
     intercept[ClassCastException] {
       NetFlowFilters.convertFilter(GreaterThan("col1", "10"), catalog)
     }
+  }
+
+  //////////////////////////////////////////////////////////////
+  // Update filter based on statistics
+  //////////////////////////////////////////////////////////////
+  test("update filter - eq") {
+    val col4 = catalog.getColumn("col4").internalColumn
+    var filter: FilterPredicate = null
+    // Equality
+    filter = FilterApi.eq(col4, 5L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), filter)
+
+    // Not in the set
+    filter = FilterApi.eq(col4, 6L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(false))
+  }
+
+  test("update filter - in") {
+    val col4 = catalog.getColumn("col4").internalColumn
+    var filter: FilterPredicate = null
+    // In equality
+    filter = inFilter(col4, Array(1L, 2L, 3L))
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), inFilter(col4, Array(1L)))
+
+    // Not in the set
+    filter = inFilter(col4, Array(100L, 101L))
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), inFilter(col4, Array()))
+  }
+
+  test("update filter - gt") {
+    val col4 = catalog.getColumn("col4").internalColumn
+    var filter: FilterPredicate = null
+
+    // Value is within the range
+    filter = FilterApi.gt(col4, 4L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), filter)
+
+    // Value is less than min
+    filter = FilterApi.gt(col4, -1L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(true))
+
+    // Value equals min
+    filter = FilterApi.gt(col4, 1L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), filter)
+
+    // Value is greater than max
+    filter = FilterApi.gt(col4, 15L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(false))
+
+    // Value equals max
+    filter = FilterApi.gt(col4, 12L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(false))
+  }
+
+  test("update filter - ge") {
+    val col4 = catalog.getColumn("col4").internalColumn
+    var filter: FilterPredicate = null
+
+    // Value is within the range
+    filter = FilterApi.ge(col4, 4L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), filter)
+
+    // Value is less than min
+    filter = FilterApi.ge(col4, -1L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(true))
+
+    // Value equals min
+    filter = FilterApi.ge(col4, 1L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(true))
+
+    // Value is greater than max
+    filter = FilterApi.ge(col4, 15L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(false))
+
+    // Value equals max
+    filter = FilterApi.ge(col4, 12L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), filter)
+  }
+
+  test("update filter - lt") {
+    val col4 = catalog.getColumn("col4").internalColumn
+    var filter: FilterPredicate = null
+
+    // Value is within the range
+    filter = FilterApi.lt(col4, 4L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), filter)
+
+    // Value is less than min
+    filter = FilterApi.lt(col4, -1L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(false))
+
+    // Value equals min
+    filter = FilterApi.lt(col4, 1L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(false))
+
+    // Value is greater than max
+    filter = FilterApi.lt(col4, 15L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(true))
+
+    // Value equals max
+    filter = FilterApi.lt(col4, 12L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), filter)
+  }
+
+  test("update filter - le") {
+    val col4 = catalog.getColumn("col4").internalColumn
+    var filter: FilterPredicate = null
+
+    // Value is within the range
+    filter = FilterApi.le(col4, 4L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), filter)
+
+    // Value is less than min
+    filter = FilterApi.le(col4, -1L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(false))
+
+    // Value equals min
+    filter = FilterApi.le(col4, 1L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), filter)
+
+    // Value is greater than max
+    filter = FilterApi.le(col4, 15L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(true))
+
+    // Value equals max
+    filter = FilterApi.le(col4, 12L)
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes), FilterApi.trivial(true))
+  }
+
+  test("update filter - and") {
+    val col2 = catalog.getColumn("col2").internalColumn
+    val col3 = catalog.getColumn("col3").internalColumn
+    val col4 = catalog.getColumn("col4").internalColumn
+    var filter: FilterPredicate = null
+
+    // Case 1
+    filter = FilterApi.and(FilterApi.eq(col4, 3L), FilterApi.eq(col2, 4.toShort))
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes),
+      FilterApi.and(FilterApi.trivial(false), FilterApi.eq(col2, 4.toShort)))
+
+    // Case 2
+    filter = FilterApi.and(FilterApi.eq(col3, 10), FilterApi.eq(col4, 3L))
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes),
+      FilterApi.and(FilterApi.eq(col3, 10), FilterApi.trivial(false)))
+
+    // Case 3
+    filter = FilterApi.and(FilterApi.ge(col4, 2L), FilterApi.le(col4, 20L))
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes),
+      FilterApi.and(FilterApi.ge(col4, 2L), FilterApi.trivial(true)))
+  }
+
+  test("update filter - or") {
+    val col2 = catalog.getColumn("col2").internalColumn
+    val col3 = catalog.getColumn("col3").internalColumn
+    val col4 = catalog.getColumn("col4").internalColumn
+    var filter: FilterPredicate = null
+
+    // Case 1
+    filter = FilterApi.or(FilterApi.eq(col4, 3L), FilterApi.eq(col2, 5.toShort))
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes),
+      FilterApi.or(FilterApi.trivial(false), FilterApi.trivial(false)))
+
+    // Case 2
+    filter = FilterApi.or(FilterApi.eq(col3, 10), FilterApi.eq(col4, 3L))
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes),
+      FilterApi.or(FilterApi.eq(col3, 10), FilterApi.trivial(false)))
+
+    // Case 3
+    filter = FilterApi.or(FilterApi.lt(col4, 2L), FilterApi.gt(col4, 12L))
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes),
+      FilterApi.or(FilterApi.lt(col4, 2L), FilterApi.trivial(false)))
+  }
+
+  test("update filter - not") {
+    val col2 = catalog.getColumn("col2").internalColumn
+    val col3 = catalog.getColumn("col3").internalColumn
+    val col4 = catalog.getColumn("col4").internalColumn
+    var filter: FilterPredicate = null
+
+    filter = FilterApi.not(FilterApi.eq(col4, 3L))
+    compareFilter(NetFlowFilters.updateFilter(filter, attributes),
+      FilterApi.not(FilterApi.trivial(false)))
   }
 }

--- a/src/test/scala/com/github/sadikovi/spark/netflow/index/StatisticsSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/index/StatisticsSuite.scala
@@ -124,6 +124,50 @@ class StatisticsSuite extends UnitTestSpec {
     attr.containsInRange(6) should be (Some(false))
   }
 
+  test("boundary query - lessThanMax") {
+    val attr = Attribute[Int]("a", 2)
+    attr.addValue(3)
+    attr.addValue(10)
+    attr.lessThanMax(4) should be (Some(true))
+    attr.lessThanMax(10) should be (Some(false))
+    attr.lessThanMax(12) should be (Some(false))
+    attr.lessThanMax(3) should be (Some(true))
+    attr.lessThanMax(-1) should be (Some(true))
+  }
+
+  test("boundary query - lessOrEqualMax") {
+    val attr = Attribute[Int]("a", 2)
+    attr.addValue(3)
+    attr.addValue(10)
+    attr.lessOrEqualMax(4) should be (Some(true))
+    attr.lessOrEqualMax(10) should be (Some(true))
+    attr.lessOrEqualMax(12) should be (Some(false))
+    attr.lessOrEqualMax(3) should be (Some(true))
+    attr.lessOrEqualMax(-1) should be (Some(true))
+  }
+
+  test("boundary query - greaterThanMin") {
+    val attr = Attribute[Int]("a", 2)
+    attr.addValue(3)
+    attr.addValue(10)
+    attr.greaterThanMin(4) should be (Some(true))
+    attr.greaterThanMin(10) should be (Some(true))
+    attr.greaterThanMin(12) should be (Some(true))
+    attr.greaterThanMin(3) should be (Some(false))
+    attr.greaterThanMin(-1) should be (Some(false))
+  }
+
+  test("boundary query - greaterOrEqualMin") {
+    val attr = Attribute[Int]("a", 2)
+    attr.addValue(3)
+    attr.addValue(10)
+    attr.greaterOrEqualMin(4) should be (Some(true))
+    attr.greaterOrEqualMin(10) should be (Some(true))
+    attr.greaterOrEqualMin(12) should be (Some(true))
+    attr.greaterOrEqualMin(3) should be (Some(true))
+    attr.greaterOrEqualMin(-1) should be (Some(false))
+  }
+
   test("get value from attribute for set mode") {
     val attr = Attribute[Int]("a", 4)
     attr.addValue(3)

--- a/src/test/scala/com/github/sadikovi/spark/netflow/index/StatisticsSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/index/StatisticsSuite.scala
@@ -163,4 +163,66 @@ class StatisticsSuite extends UnitTestSpec {
     b.getClassTag() should be (classOf[Int])
     c.getClassTag() should be (classOf[Long])
   }
+
+  test("check null on empty attribute") {
+    val attr = Attribute[Int]("a", _ < _, 7)
+    attr.containsNull() should be (true)
+  }
+
+  test("check null on non-null attribute") {
+    val attr = Attribute[Int]("a", _ < _, 7)
+    attr.addValue(1)
+    attr.addValue(2)
+    attr.containsNull() should be (false)
+  }
+
+  test("check null on null attribute") {
+    val attr = Attribute[String]("a", _ < _, 7)
+    attr.addValue("a")
+    attr.addValue("b")
+    attr.addValue(null)
+    attr.containsNull() should be (true)
+  }
+
+  test("check null on manually set attribute 1") {
+    val attr = Attribute[String]("a", _ < _, 7)
+    attr.setCount(10)
+    attr.setMinMax("a", null)
+    attr.containsNull() should be (true)
+  }
+
+  test("check null on manually set attribute 2") {
+    val attr = Attribute[String]("a", _ < _, 7)
+    attr.setMinMax("a", "b")
+    attr.containsNull() should be (false)
+  }
+
+  test("check null on manually set attribute 3") {
+    val attr = Attribute[String]("a", _ < _, 7)
+    val set = new JHashSet[String]()
+    set.add(null)
+    attr.setMinMax("a", "b")
+    attr.setSet(set)
+    attr.containsNull() should be (true)
+  }
+
+  test("attribute contains null in range") {
+    var attr = Attribute[String]("a", _ < _, 7)
+    attr.addValue("a")
+    attr.containsInRange(null) should be (Some(false))
+
+    attr = Attribute[String]("a", _ < _, 1)
+    attr.addValue("a")
+    attr.containsInRange(null) should be (None)
+  }
+
+  test("attribute contains null in set") {
+    var attr = Attribute[String]("a", _ < _, 4)
+    attr.addValue("a")
+    attr.containsInSet(null) should be (Some(false))
+
+    attr = Attribute[String]("a", _ < _, 4)
+    attr.addValue(null)
+    attr.containsInSet(null) should be (Some(true))
+  }
 }

--- a/src/test/scala/com/github/sadikovi/spark/netflow/index/StatisticsSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/index/StatisticsSuite.scala
@@ -59,7 +59,7 @@ class StatisticsSuite extends UnitTestSpec {
   }
 
   test("create and update attribute") {
-    val attr = Attribute[Int]("a", _ < _, 7)
+    val attr = Attribute[Int]("a", 7)
     for (i <- 1 to 3) {
       attr.addValue(i)
     }
@@ -69,7 +69,7 @@ class StatisticsSuite extends UnitTestSpec {
   }
 
   test("get value from attribute for range mode") {
-    val attr = Attribute[Int]("a", _ < _, 2)
+    val attr = Attribute[Int]("a", 2)
     attr.addValue(3)
     attr.addValue(5)
     attr.containsInRange(2) should be (Some(false))
@@ -80,7 +80,7 @@ class StatisticsSuite extends UnitTestSpec {
   }
 
   test("get value from attribute for set mode") {
-    val attr = Attribute[Int]("a", _ < _, 4)
+    val attr = Attribute[Int]("a", 4)
     attr.addValue(3)
     attr.addValue(5)
     attr.containsInSet(2) should be (Some(false))
@@ -91,14 +91,14 @@ class StatisticsSuite extends UnitTestSpec {
   }
 
   test("check value using empty attribute") {
-    val attr = Attribute[Int]("a", _ < _, 7)
+    val attr = Attribute[Int]("a", 7)
     attr.getCount() should be (Some(0))
     attr.containsInRange(5) should be (Some(false))
     attr.containsInSet(5) should be (Some(false))
   }
 
   test("get value from attribute for count mode") {
-    val attr = Attribute[Int]("a", _ < _, 1)
+    val attr = Attribute[Int]("a", 1)
     attr.getCount() should be (Some(0))
     attr.addValue(3)
     attr.addValue(3)
@@ -106,14 +106,14 @@ class StatisticsSuite extends UnitTestSpec {
   }
 
   test("get value from attribute for incorrect mode") {
-    val attr = Attribute[Int]("a", _ < _, 8)
+    val attr = Attribute[Int]("a", 8)
     attr.getCount() should be (None)
     attr.containsInRange(1) should be (None)
     attr.containsInSet(1) should be (None)
   }
 
   test("update values of attribute directly") {
-    val attr = Attribute[Int]("a", _ < _, 7)
+    val attr = Attribute[Int]("a", 7)
     attr.setCount(10)
     attr.setMinMax(2, 5)
     val set = new JHashSet[Int]()
@@ -127,7 +127,7 @@ class StatisticsSuite extends UnitTestSpec {
   }
 
   test("fail when updating attribute for unset mode") {
-    val attr = Attribute[Int]("a", _ < _, 8)
+    val attr = Attribute[Int]("a", 8)
     intercept[IllegalArgumentException] {
       attr.setCount(1)
     }
@@ -142,42 +142,42 @@ class StatisticsSuite extends UnitTestSpec {
   }
 
   test("get internal count, min/max, set for attribute") {
-    val attr = Attribute[Int]("a", _ < _, 7)
+    val attr = Attribute[Int]("a", 7)
     attr.getCount() should be (Some(0))
     attr.getMinMax() should be (Some(null, null))
     attr.getSet() should be (Some(new JHashSet[Int]()))
   }
 
   test("get internal count for attribute") {
-    val attr = Attribute[Int]("a", _ < _, 1)
+    val attr = Attribute[Int]("a", 1)
     attr.getCount() should be (Some(0))
     attr.getMinMax() should be (None)
     attr.getSet() should be (None)
   }
 
   test("get runtime class") {
-    val a = Attribute[Short]("a", _ < _, 7)
-    val b = Attribute[Int]("b", _ < _, 7)
-    val c = Attribute[Long]("c", _ < _, 7)
+    val a = Attribute[Short]("a", 7)
+    val b = Attribute[Int]("b", 7)
+    val c = Attribute[Long]("c", 7)
     a.getClassTag() should be (classOf[Short])
     b.getClassTag() should be (classOf[Int])
     c.getClassTag() should be (classOf[Long])
   }
 
   test("check null on empty attribute") {
-    val attr = Attribute[Int]("a", _ < _, 7)
+    val attr = Attribute[Int]("a", 7)
     attr.containsNull() should be (true)
   }
 
   test("check null on non-null attribute") {
-    val attr = Attribute[Int]("a", _ < _, 7)
+    val attr = Attribute[Int]("a", 7)
     attr.addValue(1)
     attr.addValue(2)
     attr.containsNull() should be (false)
   }
 
   test("check null on null attribute") {
-    val attr = Attribute[String]("a", _ < _, 7)
+    val attr = Attribute[String]("a", 7)
     attr.addValue("a")
     attr.addValue("b")
     attr.addValue(null)
@@ -185,20 +185,20 @@ class StatisticsSuite extends UnitTestSpec {
   }
 
   test("check null on manually set attribute 1") {
-    val attr = Attribute[String]("a", _ < _, 7)
+    val attr = Attribute[String]("a", 7)
     attr.setCount(10)
     attr.setMinMax("a", null)
     attr.containsNull() should be (true)
   }
 
   test("check null on manually set attribute 2") {
-    val attr = Attribute[String]("a", _ < _, 7)
+    val attr = Attribute[String]("a", 7)
     attr.setMinMax("a", "b")
     attr.containsNull() should be (false)
   }
 
   test("check null on manually set attribute 3") {
-    val attr = Attribute[String]("a", _ < _, 7)
+    val attr = Attribute[String]("a", 7)
     val set = new JHashSet[String]()
     set.add(null)
     attr.setMinMax("a", "b")
@@ -207,21 +207,21 @@ class StatisticsSuite extends UnitTestSpec {
   }
 
   test("attribute contains null in range") {
-    var attr = Attribute[String]("a", _ < _, 7)
+    var attr = Attribute[String]("a", 7)
     attr.addValue("a")
     attr.containsInRange(null) should be (Some(false))
 
-    attr = Attribute[String]("a", _ < _, 1)
+    attr = Attribute[String]("a", 1)
     attr.addValue("a")
     attr.containsInRange(null) should be (None)
   }
 
   test("attribute contains null in set") {
-    var attr = Attribute[String]("a", _ < _, 4)
+    var attr = Attribute[String]("a", 4)
     attr.addValue("a")
     attr.containsInSet(null) should be (Some(false))
 
-    attr = Attribute[String]("a", _ < _, 4)
+    attr = Attribute[String]("a", 4)
     attr.addValue(null)
     attr.containsInSet(null) should be (Some(true))
   }

--- a/src/test/scala/com/github/sadikovi/spark/netflow/index/StatisticsSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/index/StatisticsSuite.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.sadikovi.spark.netflow.sources
+package com.github.sadikovi.spark.netflow.index
 
 import java.util.{HashSet => JHashSet}
 import com.github.sadikovi.testutil.UnitTestSpec
@@ -90,6 +90,13 @@ class StatisticsSuite extends UnitTestSpec {
     attr.containsInSet(6) should be (Some(false))
   }
 
+  test("check value using empty attribute") {
+    val attr = Attribute[Int]("a", _ < _, 7)
+    attr.getCount() should be (Some(0))
+    attr.containsInRange(5) should be (Some(false))
+    attr.containsInSet(5) should be (Some(false))
+  }
+
   test("get value from attribute for count mode") {
     val attr = Attribute[Int]("a", _ < _, 1)
     attr.getCount() should be (Some(0))
@@ -132,5 +139,28 @@ class StatisticsSuite extends UnitTestSpec {
     intercept[IllegalArgumentException] {
       attr.setSet(new JHashSet[Int]())
     }
+  }
+
+  test("get internal count, min/max, set for attribute") {
+    val attr = Attribute[Int]("a", _ < _, 7)
+    attr.getCount() should be (Some(0))
+    attr.getMinMax() should be (Some(null, null))
+    attr.getSet() should be (Some(new JHashSet[Int]()))
+  }
+
+  test("get internal count for attribute") {
+    val attr = Attribute[Int]("a", _ < _, 1)
+    attr.getCount() should be (Some(0))
+    attr.getMinMax() should be (None)
+    attr.getSet() should be (None)
+  }
+
+  test("get runtime class") {
+    val a = Attribute[Short]("a", _ < _, 7)
+    val b = Attribute[Int]("b", _ < _, 7)
+    val c = Attribute[Long]("c", _ < _, 7)
+    a.getClassTag() should be (classOf[Short])
+    b.getClassTag() should be (classOf[Int])
+    c.getClassTag() should be (classOf[Long])
   }
 }

--- a/src/test/scala/com/github/sadikovi/spark/netflow/sources/PartitionModeSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/sources/PartitionModeSuite.scala
@@ -34,16 +34,16 @@ class PartitionModeSuite extends UnitTestSpec {
   }
 
   test("auto partition mode - single element") {
-    val seq = Seq(NetFlowFileStatus(5, "", 10, 0))
+    val seq = Seq(NetFlowFileStatus(5, "", 10, 0, None))
     val bins = autoMode.tryToPartition(seq)
-    bins should be (Seq(Seq(NetFlowFileStatus(5, "", 10, 0))))
+    bins should be (Seq(Seq(NetFlowFileStatus(5, "", 10, 0, None))))
   }
 
   test("auto partition mode - split file per partition, when <= best size") {
     val seq = Seq(
-      NetFlowFileStatus(5, "", 10, 0),
-      NetFlowFileStatus(5, "", 22, 0),
-      NetFlowFileStatus(5, "", 150, 0)
+      NetFlowFileStatus(5, "", 10, 0, None),
+      NetFlowFileStatus(5, "", 22, 0, None),
+      NetFlowFileStatus(5, "", 150, 0, None)
     )
     val bins = autoMode.tryToPartition(seq)
     bins should be (Seq(Seq(seq(0)), Seq(seq(1)), Seq(seq(2))))
@@ -51,10 +51,10 @@ class PartitionModeSuite extends UnitTestSpec {
 
   test("auto partition mode 2 - split file per partition, when <= best size") {
     val seq = Seq(
-      NetFlowFileStatus(5, "", 10, 0),
-      NetFlowFileStatus(5, "", 122, 0),
-      NetFlowFileStatus(5, "", 150, 0),
-      NetFlowFileStatus(5, "", 130, 0)
+      NetFlowFileStatus(5, "", 10, 0, None),
+      NetFlowFileStatus(5, "", 122, 0, None),
+      NetFlowFileStatus(5, "", 150, 0, None),
+      NetFlowFileStatus(5, "", 130, 0, None)
     )
     val bins = autoMode.tryToPartition(seq)
     bins should be (Seq(Seq(seq(0)), Seq(seq(1)), Seq(seq(2)), Seq(seq(3))))
@@ -62,202 +62,202 @@ class PartitionModeSuite extends UnitTestSpec {
 
   test("auto partition mode - simple split") {
     val seq = Seq(
-      NetFlowFileStatus(5, "", 10, 0),
-      NetFlowFileStatus(5, "", 22, 0),
-      NetFlowFileStatus(5, "", 150, 0),
-      NetFlowFileStatus(5, "", 30, 0),
-      NetFlowFileStatus(5, "", 30, 0)
+      NetFlowFileStatus(5, "", 10, 0, None),
+      NetFlowFileStatus(5, "", 22, 0, None),
+      NetFlowFileStatus(5, "", 150, 0, None),
+      NetFlowFileStatus(5, "", 30, 0, None),
+      NetFlowFileStatus(5, "", 30, 0, None)
     )
     val bins = autoMode.tryToPartition(seq)
     bins should be (Seq(
-      Seq(NetFlowFileStatus(5, "", 150, 0)),
-      Seq(NetFlowFileStatus(5, "", 30, 0),
-        NetFlowFileStatus(5, "", 30, 0),
-        NetFlowFileStatus(5, "", 22, 0),
-        NetFlowFileStatus(5, "", 10, 0))
+      Seq(NetFlowFileStatus(5, "", 150, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 30, 0, None),
+        NetFlowFileStatus(5, "", 30, 0, None),
+        NetFlowFileStatus(5, "", 22, 0, None),
+        NetFlowFileStatus(5, "", 10, 0, None))
     ))
   }
 
   test("auto partition mode - complex split 1") {
     val seq = Seq(
-      NetFlowFileStatus(5, "", 10, 0),
-      NetFlowFileStatus(5, "", 22, 0),
-      NetFlowFileStatus(5, "", 150, 0),
-      NetFlowFileStatus(5, "", 200, 0),
-      NetFlowFileStatus(5, "", 1, 0),
-      NetFlowFileStatus(5, "", 5, 0),
-      NetFlowFileStatus(5, "", 7, 0),
-      NetFlowFileStatus(5, "", 19, 0),
-      NetFlowFileStatus(5, "", 90, 0),
-      NetFlowFileStatus(5, "", 4, 0),
-      NetFlowFileStatus(5, "", 4, 0),
-      NetFlowFileStatus(5, "", 4, 0),
-      NetFlowFileStatus(5, "", 19, 0),
-      NetFlowFileStatus(5, "", 50, 0),
-      NetFlowFileStatus(5, "", 45, 0),
-      NetFlowFileStatus(5, "", 39, 0),
-      NetFlowFileStatus(5, "", 39, 0),
-      NetFlowFileStatus(5, "", 43, 0),
-      NetFlowFileStatus(5, "", 21, 0),
-      NetFlowFileStatus(5, "", 45, 0),
-      NetFlowFileStatus(5, "", 45, 0),
-      NetFlowFileStatus(5, "", 90, 0),
-      NetFlowFileStatus(5, "", 10, 0),
-      NetFlowFileStatus(5, "", 11, 0)
+      NetFlowFileStatus(5, "", 10, 0, None),
+      NetFlowFileStatus(5, "", 22, 0, None),
+      NetFlowFileStatus(5, "", 150, 0, None),
+      NetFlowFileStatus(5, "", 200, 0, None),
+      NetFlowFileStatus(5, "", 1, 0, None),
+      NetFlowFileStatus(5, "", 5, 0, None),
+      NetFlowFileStatus(5, "", 7, 0, None),
+      NetFlowFileStatus(5, "", 19, 0, None),
+      NetFlowFileStatus(5, "", 90, 0, None),
+      NetFlowFileStatus(5, "", 4, 0, None),
+      NetFlowFileStatus(5, "", 4, 0, None),
+      NetFlowFileStatus(5, "", 4, 0, None),
+      NetFlowFileStatus(5, "", 19, 0, None),
+      NetFlowFileStatus(5, "", 50, 0, None),
+      NetFlowFileStatus(5, "", 45, 0, None),
+      NetFlowFileStatus(5, "", 39, 0, None),
+      NetFlowFileStatus(5, "", 39, 0, None),
+      NetFlowFileStatus(5, "", 43, 0, None),
+      NetFlowFileStatus(5, "", 21, 0, None),
+      NetFlowFileStatus(5, "", 45, 0, None),
+      NetFlowFileStatus(5, "", 45, 0, None),
+      NetFlowFileStatus(5, "", 90, 0, None),
+      NetFlowFileStatus(5, "", 10, 0, None),
+      NetFlowFileStatus(5, "", 11, 0, None)
     )
     val bins = autoMode.tryToPartition(seq)
     bins should be (Seq(
-      Seq(NetFlowFileStatus(5, "", 200, 0)),
-      Seq(NetFlowFileStatus(5, "", 150, 0)),
-      Seq(NetFlowFileStatus(5, "", 90, 0),
-        NetFlowFileStatus(5, "", 1, 0),
-        NetFlowFileStatus(5, "", 4, 0),
-        NetFlowFileStatus(5, "", 4, 0)),
-      Seq(NetFlowFileStatus(5, "", 90, 0),
-        NetFlowFileStatus(5, "", 4, 0),
-        NetFlowFileStatus(5, "", 5, 0)),
-      Seq(NetFlowFileStatus(5, "", 50, 0),
-        NetFlowFileStatus(5, "", 7, 0),
-        NetFlowFileStatus(5, "", 10, 0),
-        NetFlowFileStatus(5, "", 10, 0),
-        NetFlowFileStatus(5, "", 11, 0)),
-      Seq(NetFlowFileStatus(5, "", 45, 0),
-        NetFlowFileStatus(5, "", 19, 0),
-        NetFlowFileStatus(5, "", 19, 0)),
-      Seq(NetFlowFileStatus(5, "", 45, 0),
-        NetFlowFileStatus(5, "", 21, 0),
-        NetFlowFileStatus(5, "", 22, 0)),
-      Seq(NetFlowFileStatus(5, "", 45, 0),
-        NetFlowFileStatus(5, "", 43, 0)),
-      Seq(NetFlowFileStatus(5, "", 39, 0),
-        NetFlowFileStatus(5, "", 39, 0))
+      Seq(NetFlowFileStatus(5, "", 200, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 150, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 90, 0, None),
+        NetFlowFileStatus(5, "", 1, 0, None),
+        NetFlowFileStatus(5, "", 4, 0, None),
+        NetFlowFileStatus(5, "", 4, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 90, 0, None),
+        NetFlowFileStatus(5, "", 4, 0, None),
+        NetFlowFileStatus(5, "", 5, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 50, 0, None),
+        NetFlowFileStatus(5, "", 7, 0, None),
+        NetFlowFileStatus(5, "", 10, 0, None),
+        NetFlowFileStatus(5, "", 10, 0, None),
+        NetFlowFileStatus(5, "", 11, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 45, 0, None),
+        NetFlowFileStatus(5, "", 19, 0, None),
+        NetFlowFileStatus(5, "", 19, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 45, 0, None),
+        NetFlowFileStatus(5, "", 21, 0, None),
+        NetFlowFileStatus(5, "", 22, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 45, 0, None),
+        NetFlowFileStatus(5, "", 43, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 39, 0, None),
+        NetFlowFileStatus(5, "", 39, 0, None))
     ))
   }
 
   test("auto partition mode - complex split 2") {
     val seq = Seq(
-      NetFlowFileStatus(5, "", 10, 0),
-      NetFlowFileStatus(5, "", 22, 0),
-      NetFlowFileStatus(5, "", 150, 0),
-      NetFlowFileStatus(5, "", 200, 0),
-      NetFlowFileStatus(5, "", 120, 0),
-      NetFlowFileStatus(5, "", 500, 0),
-      NetFlowFileStatus(5, "", 170, 0),
-      NetFlowFileStatus(5, "", 190, 0),
-      NetFlowFileStatus(5, "", 190, 0),
-      NetFlowFileStatus(5, "", 4, 0),
-      NetFlowFileStatus(5, "", 4, 0),
-      NetFlowFileStatus(5, "", 4, 0),
-      NetFlowFileStatus(5, "", 19, 0),
-      NetFlowFileStatus(5, "", 50, 0),
-      NetFlowFileStatus(5, "", 45, 0),
-      NetFlowFileStatus(5, "", 39, 0),
-      NetFlowFileStatus(5, "", 39, 0),
-      NetFlowFileStatus(5, "", 430, 0),
-      NetFlowFileStatus(5, "", 210, 0),
-      NetFlowFileStatus(5, "", 240, 0),
-      NetFlowFileStatus(5, "", 145, 0),
-      NetFlowFileStatus(5, "", 190, 0),
-      NetFlowFileStatus(5, "", 100, 0),
-      NetFlowFileStatus(5, "", 110, 0)
+      NetFlowFileStatus(5, "", 10, 0, None),
+      NetFlowFileStatus(5, "", 22, 0, None),
+      NetFlowFileStatus(5, "", 150, 0, None),
+      NetFlowFileStatus(5, "", 200, 0, None),
+      NetFlowFileStatus(5, "", 120, 0, None),
+      NetFlowFileStatus(5, "", 500, 0, None),
+      NetFlowFileStatus(5, "", 170, 0, None),
+      NetFlowFileStatus(5, "", 190, 0, None),
+      NetFlowFileStatus(5, "", 190, 0, None),
+      NetFlowFileStatus(5, "", 4, 0, None),
+      NetFlowFileStatus(5, "", 4, 0, None),
+      NetFlowFileStatus(5, "", 4, 0, None),
+      NetFlowFileStatus(5, "", 19, 0, None),
+      NetFlowFileStatus(5, "", 50, 0, None),
+      NetFlowFileStatus(5, "", 45, 0, None),
+      NetFlowFileStatus(5, "", 39, 0, None),
+      NetFlowFileStatus(5, "", 39, 0, None),
+      NetFlowFileStatus(5, "", 430, 0, None),
+      NetFlowFileStatus(5, "", 210, 0, None),
+      NetFlowFileStatus(5, "", 240, 0, None),
+      NetFlowFileStatus(5, "", 145, 0, None),
+      NetFlowFileStatus(5, "", 190, 0, None),
+      NetFlowFileStatus(5, "", 100, 0, None),
+      NetFlowFileStatus(5, "", 110, 0, None)
     )
     val bins = autoMode.tryToPartition(seq)
     bins should be (Seq(
-      Seq(NetFlowFileStatus(5, "", 500, 0)),
-      Seq(NetFlowFileStatus(5, "", 430, 0)),
-      Seq(NetFlowFileStatus(5, "", 240, 0)),
-      Seq(NetFlowFileStatus(5, "", 210, 0)),
-      Seq(NetFlowFileStatus(5, "", 200, 0)),
-      Seq(NetFlowFileStatus(5, "", 190, 0)),
-      Seq(NetFlowFileStatus(5, "", 190, 0)),
-      Seq(NetFlowFileStatus(5, "", 190, 0)),
-      Seq(NetFlowFileStatus(5, "", 170, 0)),
-      Seq(NetFlowFileStatus(5, "", 150, 0)),
-      Seq(NetFlowFileStatus(5, "", 145, 0)),
-      Seq(NetFlowFileStatus(5, "", 120, 0)),
-      Seq(NetFlowFileStatus(5, "", 110, 0)),
-      Seq(NetFlowFileStatus(5, "", 100, 0)),
-      Seq(NetFlowFileStatus(5, "", 50, 0),
-        NetFlowFileStatus(5, "", 4, 0),
-        NetFlowFileStatus(5, "", 4, 0),
-        NetFlowFileStatus(5, "", 4, 0),
-        NetFlowFileStatus(5, "", 10, 0),
-        NetFlowFileStatus(5, "", 19, 0)),
-      Seq(NetFlowFileStatus(5, "", 45, 0),
-        NetFlowFileStatus(5, "", 39, 0)),
-      Seq(NetFlowFileStatus(5, "", 39, 0),
-        NetFlowFileStatus(5, "", 22, 0))
+      Seq(NetFlowFileStatus(5, "", 500, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 430, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 240, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 210, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 200, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 190, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 190, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 190, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 170, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 150, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 145, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 120, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 110, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 100, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 50, 0, None),
+        NetFlowFileStatus(5, "", 4, 0, None),
+        NetFlowFileStatus(5, "", 4, 0, None),
+        NetFlowFileStatus(5, "", 4, 0, None),
+        NetFlowFileStatus(5, "", 10, 0, None),
+        NetFlowFileStatus(5, "", 19, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 45, 0, None),
+        NetFlowFileStatus(5, "", 39, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 39, 0, None),
+        NetFlowFileStatus(5, "", 22, 0, None))
     ))
   }
 
   test("auto partition mode - 2 buckets split") {
     val seq = Seq(
-      NetFlowFileStatus(5, "", 80, 0),
-      NetFlowFileStatus(5, "", 40, 0),
-      NetFlowFileStatus(5, "", 40, 0),
-      NetFlowFileStatus(5, "", 20, 0),
-      NetFlowFileStatus(5, "", 20, 0)
+      NetFlowFileStatus(5, "", 80, 0, None),
+      NetFlowFileStatus(5, "", 40, 0, None),
+      NetFlowFileStatus(5, "", 40, 0, None),
+      NetFlowFileStatus(5, "", 20, 0, None),
+      NetFlowFileStatus(5, "", 20, 0, None)
     )
     val bins = autoMode.tryToPartition(seq)
     bins should be (Seq(
-      Seq(NetFlowFileStatus(5, "", 80, 0),
-        NetFlowFileStatus(5, "", 20, 0)),
-      Seq(NetFlowFileStatus(5, "", 40, 0),
-        NetFlowFileStatus(5, "", 40, 0),
-        NetFlowFileStatus(5, "", 20, 0))
+      Seq(NetFlowFileStatus(5, "", 80, 0, None),
+        NetFlowFileStatus(5, "", 20, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 40, 0, None),
+        NetFlowFileStatus(5, "", 40, 0, None),
+        NetFlowFileStatus(5, "", 20, 0, None))
     ))
   }
 
   test("auto partition mode - 2 buckets unequal split") {
     val seq = Seq(
-      NetFlowFileStatus(5, "", 80, 0),
-      NetFlowFileStatus(5, "", 19, 0),
-      NetFlowFileStatus(5, "", 10, 0),
-      NetFlowFileStatus(5, "", 4, 0),
-      NetFlowFileStatus(5, "", 5, 0)
+      NetFlowFileStatus(5, "", 80, 0, None),
+      NetFlowFileStatus(5, "", 19, 0, None),
+      NetFlowFileStatus(5, "", 10, 0, None),
+      NetFlowFileStatus(5, "", 4, 0, None),
+      NetFlowFileStatus(5, "", 5, 0, None)
     )
     val bins = autoMode.tryToPartition(seq)
     bins should be (Seq(
-      Seq(NetFlowFileStatus(5, "", 80, 0),
-        NetFlowFileStatus(5, "", 19, 0)),
-      Seq(NetFlowFileStatus(5, "", 10, 0),
-        NetFlowFileStatus(5, "", 5, 0),
-        NetFlowFileStatus(5, "", 4, 0))
+      Seq(NetFlowFileStatus(5, "", 80, 0, None),
+        NetFlowFileStatus(5, "", 19, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 10, 0, None),
+        NetFlowFileStatus(5, "", 5, 0, None),
+        NetFlowFileStatus(5, "", 4, 0, None))
     ))
   }
 
   test("default partition mode - None as number of slices") {
     val defaultMode = DefaultPartitionMode(None)
     val seq = Seq(
-      NetFlowFileStatus(5, "", 84, 0),
-      NetFlowFileStatus(5, "", 12, 0),
-      NetFlowFileStatus(5, "", 15, 0),
-      NetFlowFileStatus(5, "", 3, 0)
+      NetFlowFileStatus(5, "", 84, 0, None),
+      NetFlowFileStatus(5, "", 12, 0, None),
+      NetFlowFileStatus(5, "", 15, 0, None),
+      NetFlowFileStatus(5, "", 3, 0, None)
     )
     val bins = defaultMode.tryToPartition(seq)
     bins should be (Seq(
-      Seq(NetFlowFileStatus(5, "", 84, 0)),
-      Seq(NetFlowFileStatus(5, "", 12, 0)),
-      Seq(NetFlowFileStatus(5, "", 15, 0)),
-      Seq(NetFlowFileStatus(5, "", 3, 0))
+      Seq(NetFlowFileStatus(5, "", 84, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 12, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 15, 0, None)),
+      Seq(NetFlowFileStatus(5, "", 3, 0, None))
     ))
   }
 
   test("default partition mode - 1 partition") {
     val defaultMode = DefaultPartitionMode(Option(1))
     val seq = Seq(
-      NetFlowFileStatus(5, "", 84, 0),
-      NetFlowFileStatus(5, "", 12, 0),
-      NetFlowFileStatus(5, "", 15, 0),
-      NetFlowFileStatus(5, "", 3, 0)
+      NetFlowFileStatus(5, "", 84, 0, None),
+      NetFlowFileStatus(5, "", 12, 0, None),
+      NetFlowFileStatus(5, "", 15, 0, None),
+      NetFlowFileStatus(5, "", 3, 0, None)
     )
     val bins = defaultMode.tryToPartition(seq)
     bins should be (Seq(
       Seq(
-        NetFlowFileStatus(5, "", 84, 0),
-        NetFlowFileStatus(5, "", 12, 0),
-        NetFlowFileStatus(5, "", 15, 0),
-        NetFlowFileStatus(5, "", 3, 0)
+        NetFlowFileStatus(5, "", 84, 0, None),
+        NetFlowFileStatus(5, "", 12, 0, None),
+        NetFlowFileStatus(5, "", 15, 0, None),
+        NetFlowFileStatus(5, "", 3, 0, None)
       )
     ))
   }

--- a/src/test/scala/com/github/sadikovi/spark/netflow/sources/StatisticsSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/sources/StatisticsSuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.spark.netflow.sources
+
+import com.github.sadikovi.testutil.UnitTestSpec
+
+class StatisticsSuite extends UnitTestSpec {
+  test("resolve statistics path without root") {
+    val resolver = StatisticsPathResolver(None)
+    val path = resolver.getStatisticsPath("file:/x/y/z/file")
+    path should be ("file:/x/y/z/.statistics-file")
+  }
+
+  test("resolve statistics path with root") {
+    val resolver = StatisticsPathResolver(Some("file:/a/b/c"))
+    val path = resolver.getStatisticsPath("file:/x/y/z/file")
+    path should be ("file:/a/b/c/x/y/z/.statistics-file")
+  }
+
+  test("fail if root path is null") {
+    intercept[IllegalArgumentException] {
+      StatisticsPathResolver(Some(null))
+    }
+  }
+
+  test("fail if root path is empty") {
+    intercept[IllegalArgumentException] {
+      StatisticsPathResolver(Some(""))
+    }
+  }
+
+  test("fail if file path is null") {
+    val resolver = StatisticsPathResolver(None)
+    intercept[IllegalArgumentException] {
+      resolver.getStatisticsPath(null)
+    }
+  }
+
+  test("fail if file path is empty") {
+    val resolver = StatisticsPathResolver(None)
+    intercept[IllegalArgumentException] {
+      resolver.getStatisticsPath("")
+    }
+  }
+}

--- a/src/test/scala/com/github/sadikovi/spark/netflow/sources/StatisticsSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/sources/StatisticsSuite.scala
@@ -16,6 +16,7 @@
 
 package com.github.sadikovi.spark.netflow.sources
 
+import java.util.{HashSet => JHashSet}
 import com.github.sadikovi.testutil.UnitTestSpec
 
 class StatisticsSuite extends UnitTestSpec {
@@ -54,6 +55,82 @@ class StatisticsSuite extends UnitTestSpec {
     val resolver = StatisticsPathResolver(None)
     intercept[IllegalArgumentException] {
       resolver.getStatisticsPath("")
+    }
+  }
+
+  test("create and update attribute") {
+    val attr = Attribute[Int]("a", _ < _, 7)
+    for (i <- 1 to 3) {
+      attr.addValue(i)
+    }
+    attr.getCount() should be (Some(3))
+    attr.containsInRange(2) should be (Some(true))
+    attr.containsInSet(2) should be (Some(true))
+  }
+
+  test("get value from attribute for range mode") {
+    val attr = Attribute[Int]("a", _ < _, 2)
+    attr.addValue(3)
+    attr.addValue(5)
+    attr.containsInRange(2) should be (Some(false))
+    attr.containsInRange(3) should be (Some(true))
+    attr.containsInRange(4) should be (Some(true))
+    attr.containsInRange(5) should be (Some(true))
+    attr.containsInRange(6) should be (Some(false))
+  }
+
+  test("get value from attribute for set mode") {
+    val attr = Attribute[Int]("a", _ < _, 4)
+    attr.addValue(3)
+    attr.addValue(5)
+    attr.containsInSet(2) should be (Some(false))
+    attr.containsInSet(3) should be (Some(true))
+    attr.containsInSet(4) should be (Some(false))
+    attr.containsInSet(5) should be (Some(true))
+    attr.containsInSet(6) should be (Some(false))
+  }
+
+  test("get value from attribute for count mode") {
+    val attr = Attribute[Int]("a", _ < _, 1)
+    attr.getCount() should be (Some(0))
+    attr.addValue(3)
+    attr.addValue(3)
+    attr.getCount() should be (Some(2))
+  }
+
+  test("get value from attribute for incorrect mode") {
+    val attr = Attribute[Int]("a", _ < _, 8)
+    attr.getCount() should be (None)
+    attr.containsInRange(1) should be (None)
+    attr.containsInSet(1) should be (None)
+  }
+
+  test("update values of attribute directly") {
+    val attr = Attribute[Int]("a", _ < _, 7)
+    attr.setCount(10)
+    attr.setMinMax(2, 5)
+    val set = new JHashSet[Int]()
+    set.add(2)
+    set.add(5)
+    attr.setSet(set)
+
+    attr.getCount() should be (Some(10))
+    attr.containsInRange(2) should be (Some(true))
+    attr.containsInSet(2) should be (Some(true))
+  }
+
+  test("fail when updating attribute for unset mode") {
+    val attr = Attribute[Int]("a", _ < _, 8)
+    intercept[IllegalArgumentException] {
+      attr.setCount(1)
+    }
+
+    intercept[IllegalArgumentException] {
+      attr.setMinMax(1, 2)
+    }
+
+    intercept[IllegalArgumentException] {
+      attr.setSet(new JHashSet[Int]())
     }
   }
 }


### PR DESCRIPTION
Add statistics generation for NetFlow files. This includes public interface `Attribute` to capture statistics, `StatisticsPathResolver` to resolve destination and file name, `StatisticsWriter` and `StatisticsReader` to write and read binary layout. 

The proposal to custom layout is as follows:

```
[MN1 MN2 END]
  [MN1 MN2 KEY FLAGS]
    [TYPE BYTES NUM]
      [VALUES]
    [TYPE BYTES NUM]
      [VALUES]
  [MN1 MN2 KEY FLAGS]
  ...
```
