### PR TITLE
Replace klass with clazz

### DIFF
--- a/src/main/java/com/github/sadikovi/netflowlib/ScanPlanner.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/ScanPlanner.java
@@ -155,25 +155,25 @@ public final class ScanPlanner extends Logging implements PredicateTransform {
 
   // Method to compare two objects based on provided class. Interface is similar to `compareTo`
   // method from `Comparable` interface. Note that only certain types are supported
-  protected int compare(Class<?> klass, Object it, Object that) {
-    if (klass.equals(Byte.class)) {
+  protected int compare(Class<?> clazz, Object it, Object that) {
+    if (clazz.equals(Byte.class)) {
       Byte itValue = Byte.class.cast(it);
       Byte thatValue = Byte.class.cast(that);
       return itValue.compareTo(thatValue);
-    } else if (klass.equals(Short.class)) {
+    } else if (clazz.equals(Short.class)) {
       Short itValue = Short.class.cast(it);
       Short thatValue = Short.class.cast(that);
       return itValue.compareTo(thatValue);
-    } else if (klass.equals(Integer.class)) {
+    } else if (clazz.equals(Integer.class)) {
       Integer itValue = Integer.class.cast(it);
       Integer thatValue = Integer.class.cast(that);
       return itValue.compareTo(thatValue);
-    } else if (klass.equals(Long.class)) {
+    } else if (clazz.equals(Long.class)) {
       Long itValue = Long.class.cast(it);
       Long thatValue = Long.class.cast(that);
       return itValue.compareTo(thatValue);
     } else {
-      throw new UnsupportedOperationException("Unsupported read type " + klass.toString());
+      throw new UnsupportedOperationException("Unsupported read type " + clazz.toString());
     }
   }
 

--- a/src/main/java/com/github/sadikovi/netflowlib/predicate/Operators.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/predicate/Operators.java
@@ -60,7 +60,7 @@ public final class Operators {
       this.inspector = getValueInspector(column.getColumnType());
     }
 
-    protected abstract ValueInspector getValueInspector(Class<?> klass);
+    protected abstract ValueInspector getValueInspector(Class<?> clazz);
 
     public Column getColumn() {
       return column;
@@ -126,29 +126,29 @@ public final class Operators {
     }
 
     @Override
-    protected ValueInspector getValueInspector(Class<?> klass) {
-      if (klass.equals(Byte.class)) {
+    protected ValueInspector getValueInspector(Class<?> clazz) {
+      if (clazz.equals(Byte.class)) {
         return new ValueInspector() {
           @Override
           public void update(byte value) {
             setResult(value == Byte.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Short.class)) {
+      } else if (clazz.equals(Short.class)) {
         return new ValueInspector() {
           @Override
           public void update(short value) {
             setResult(value == Short.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Integer.class)) {
+      } else if (clazz.equals(Integer.class)) {
         return new ValueInspector() {
           @Override
           public void update(int value) {
             setResult(value == Integer.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Long.class)) {
+      } else if (clazz.equals(Long.class)) {
         return new ValueInspector() {
           @Override
           public void update(long value) {
@@ -175,29 +175,29 @@ public final class Operators {
     }
 
     @Override
-    protected ValueInspector getValueInspector(Class<?> klass) {
-      if (klass.equals(Byte.class)) {
+    protected ValueInspector getValueInspector(Class<?> clazz) {
+      if (clazz.equals(Byte.class)) {
         return new ValueInspector() {
           @Override
           public void update(byte value) {
             setResult(value > Byte.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Short.class)) {
+      } else if (clazz.equals(Short.class)) {
         return new ValueInspector() {
           @Override
           public void update(short value) {
             setResult(value > Short.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Integer.class)) {
+      } else if (clazz.equals(Integer.class)) {
         return new ValueInspector() {
           @Override
           public void update(int value) {
             setResult(value > Integer.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Long.class)) {
+      } else if (clazz.equals(Long.class)) {
         return new ValueInspector() {
           @Override
           public void update(long value) {
@@ -224,29 +224,29 @@ public final class Operators {
     }
 
     @Override
-    protected ValueInspector getValueInspector(Class<?> klass) {
-      if (klass.equals(Byte.class)) {
+    protected ValueInspector getValueInspector(Class<?> clazz) {
+      if (clazz.equals(Byte.class)) {
         return new ValueInspector() {
           @Override
           public void update(byte value) {
             setResult(value >= Byte.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Short.class)) {
+      } else if (clazz.equals(Short.class)) {
         return new ValueInspector() {
           @Override
           public void update(short value) {
             setResult(value >= Short.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Integer.class)) {
+      } else if (clazz.equals(Integer.class)) {
         return new ValueInspector() {
           @Override
           public void update(int value) {
             setResult(value >= Integer.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Long.class)) {
+      } else if (clazz.equals(Long.class)) {
         return new ValueInspector() {
           @Override
           public void update(long value) {
@@ -273,29 +273,29 @@ public final class Operators {
     }
 
     @Override
-    protected ValueInspector getValueInspector(Class<?> klass) {
-      if (klass.equals(Byte.class)) {
+    protected ValueInspector getValueInspector(Class<?> clazz) {
+      if (clazz.equals(Byte.class)) {
         return new ValueInspector() {
           @Override
           public void update(byte value) {
             setResult(value < Byte.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Short.class)) {
+      } else if (clazz.equals(Short.class)) {
         return new ValueInspector() {
           @Override
           public void update(short value) {
             setResult(value < Short.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Integer.class)) {
+      } else if (clazz.equals(Integer.class)) {
         return new ValueInspector() {
           @Override
           public void update(int value) {
             setResult(value < Integer.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Long.class)) {
+      } else if (clazz.equals(Long.class)) {
         return new ValueInspector() {
           @Override
           public void update(long value) {
@@ -322,29 +322,29 @@ public final class Operators {
     }
 
     @Override
-    protected ValueInspector getValueInspector(Class<?> klass) {
-      if (klass.equals(Byte.class)) {
+    protected ValueInspector getValueInspector(Class<?> clazz) {
+      if (clazz.equals(Byte.class)) {
         return new ValueInspector() {
           @Override
           public void update(byte value) {
             setResult(value <= Byte.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Short.class)) {
+      } else if (clazz.equals(Short.class)) {
         return new ValueInspector() {
           @Override
           public void update(short value) {
             setResult(value <= Short.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Integer.class)) {
+      } else if (clazz.equals(Integer.class)) {
         return new ValueInspector() {
           @Override
           public void update(int value) {
             setResult(value <= Integer.class.cast(getValue()));
           }
         };
-      } else if (klass.equals(Long.class)) {
+      } else if (clazz.equals(Long.class)) {
         return new ValueInspector() {
           @Override
           public void update(long value) {
@@ -419,29 +419,29 @@ public final class Operators {
     }
 
     @Override
-    protected ValueInspector getValueInspector(Class<?> klass) {
-      if (klass.equals(Byte.class)) {
+    protected ValueInspector getValueInspector(Class<?> clazz) {
+      if (clazz.equals(Byte.class)) {
         return new ValueInspector() {
           @Override
           public void update(byte value) {
             setResult(getValues().contains(value));
           }
         };
-      } else if (klass.equals(Short.class)) {
+      } else if (clazz.equals(Short.class)) {
         return new ValueInspector() {
           @Override
           public void update(short value) {
             setResult(getValues().contains(value));
           }
         };
-      } else if (klass.equals(Integer.class)) {
+      } else if (clazz.equals(Integer.class)) {
         return new ValueInspector() {
           @Override
           public void update(int value) {
             setResult(getValues().contains(value));
           }
         };
-      } else if (klass.equals(Long.class)) {
+      } else if (clazz.equals(Long.class)) {
         return new ValueInspector() {
           @Override
           public void update(long value) {

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/Attribute.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/Attribute.scala
@@ -32,7 +32,7 @@ class Attribute[T](
     val lt: (T, T) => Boolean,
     val flags: Byte,
     val isNullable: Boolean)(implicit tag: ClassTag[T]) {
-  private val klass = tag.runtimeClass
+  private val clazz = tag.runtimeClass
   private var count: Long = if (isCountEnabled) 0 else Long.MinValue
   private var min: T = _
   private var max: T = _
@@ -206,7 +206,7 @@ class Attribute[T](
   }
 
   /** Get actual generic runtime class */
-  def getClassTag(): Class[_] = klass
+  def getClassTag(): Class[_] = clazz
 
   /**
    * Whether or not attribute has null values.
@@ -237,20 +237,20 @@ object Attribute {
     apply(name, flags.toByte, tag.runtimeClass.asInstanceOf[Class[T]])
   }
 
-  def apply[T: ClassTag](name: String, flags: Int, klass: Class[T]): Attribute[T] = {
+  def apply[T: ClassTag](name: String, flags: Int, clazz: Class[T]): Attribute[T] = {
     val byteFlags = flags.toByte
-    if (klass == classOf[Byte]) {
+    if (clazz == classOf[Byte]) {
       new Attribute[Byte](name, _ < _, byteFlags, false).asInstanceOf[Attribute[T]]
-    } else if (klass == classOf[Short]) {
+    } else if (clazz == classOf[Short]) {
       new Attribute[Short](name, _ < _, byteFlags, false).asInstanceOf[Attribute[T]]
-    } else if (klass == classOf[Int]) {
+    } else if (clazz == classOf[Int]) {
       new Attribute[Int](name, _ < _, byteFlags, false).asInstanceOf[Attribute[T]]
-    } else if (klass == classOf[Long]) {
+    } else if (clazz == classOf[Long]) {
       new Attribute[Long](name, _ < _, byteFlags, false).asInstanceOf[Attribute[T]]
-    } else if (klass == classOf[String]) {
+    } else if (clazz == classOf[String]) {
       new Attribute[String](name, _ < _, byteFlags, true).asInstanceOf[Attribute[T]]
     } else {
-      sys.error(s"Unsupported attribute class $klass")
+      sys.error(s"Unsupported attribute class $clazz")
     }
   }
 }

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsReader.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsReader.scala
@@ -48,11 +48,11 @@ private[spark] class StatisticsReader {
   private[index] def getAttributeParams(buffer: ByteBuf): (Byte, Class[_], Boolean, String) = {
     verify(buffer)
     val flags = buffer.readByte()
-    val klass = StatisticsUtils.getClassTag(buffer.readByte())
+    val clazz = StatisticsUtils.getClassTag(buffer.readByte())
     val hasNull = buffer.readBoolean()
     val name = StatisticsUtils.readValue(buffer, classOf[String]).asInstanceOf[String]
 
-    (flags, klass, hasNull, name)
+    (flags, clazz, hasNull, name)
   }
 
   /** Read property, and return type of property, class of values, and temporary buffer */
@@ -61,7 +61,7 @@ private[spark] class StatisticsReader {
     val tpe = buffer.readByte()
     val classBytes = buffer.readByte()
     var size = buffer.readInt()
-    val klass = StatisticsUtils.getClassTag(classBytes)
+    val clazz = StatisticsUtils.getClassTag(classBytes)
     // Temporary cache for values
     val temp = new ArrayBuffer[Any]()
     // Read values sequentially
@@ -71,10 +71,10 @@ private[spark] class StatisticsReader {
         if (isNullByte) {
           temp.append(null)
         } else {
-          temp.append(StatisticsUtils.readValue(buffer, klass))
+          temp.append(StatisticsUtils.readValue(buffer, clazz))
         }
       } else {
-        temp.append(StatisticsUtils.readValue(buffer, klass))
+        temp.append(StatisticsUtils.readValue(buffer, clazz))
       }
       size -= 1
     }
@@ -85,11 +85,11 @@ private[spark] class StatisticsReader {
   private[index] def getAttribute(buffer: ByteBuf): Attribute[_ <: Any] = {
     val params = getAttributeParams(buffer)
     val flags = params._1
-    val klass = params._2
+    val clazz = params._2
     val hasNull = params._3
     val name = params._4
 
-    val attr = Attribute(name, flags, klass)
+    val attr = Attribute(name, flags, clazz)
     // We cannot use `containsNull` when reading property, because it will account for min/max,
     // which are null for empty attribute
     attr.setNull(hasNull)

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsUtils.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsUtils.scala
@@ -57,19 +57,19 @@ object StatisticsUtils {
   }
 
   /** Get number of bytes for class, only supports numeric classes and strings for now */
-  def getBytes(klass: Class[_]): Byte = {
-    if (klass == classOf[Byte]) {
+  def getBytes(clazz: Class[_]): Byte = {
+    if (clazz == classOf[Byte]) {
       return 1
-    } else if (klass == classOf[Short]) {
+    } else if (clazz == classOf[Short]) {
       return 2
-    } else if (klass == classOf[Int]) {
+    } else if (clazz == classOf[Int]) {
       return 4
-    } else if (klass == classOf[Long]) {
+    } else if (clazz == classOf[Long]) {
       return 8
-    } else if (klass == classOf[String]) {
+    } else if (clazz == classOf[String]) {
       return 32
     } else {
-      sys.error(s"Unsuppored type $klass")
+      sys.error(s"Unsuppored type $clazz")
     }
   }
 
@@ -84,56 +84,56 @@ object StatisticsUtils {
   }
 
   /** Write value based on a provided class */
-  def writeValue(buffer: ByteBuf, value: Any, klass: Class[_]): Unit = {
-    if (klass == classOf[Byte]) {
+  def writeValue(buffer: ByteBuf, value: Any, clazz: Class[_]): Unit = {
+    if (clazz == classOf[Byte]) {
       buffer.writeByte(value.asInstanceOf[Byte].toInt)
-    } else if (klass == classOf[Short]) {
+    } else if (clazz == classOf[Short]) {
       buffer.writeShort(value.asInstanceOf[Short].toInt)
-    } else if (klass == classOf[Int]) {
+    } else if (clazz == classOf[Int]) {
       buffer.writeInt(value.asInstanceOf[Int])
-    } else if (klass == classOf[Long]) {
+    } else if (clazz == classOf[Long]) {
       buffer.writeLong(value.asInstanceOf[Long])
-    } else if (klass == classOf[String]) {
+    } else if (clazz == classOf[String]) {
       val chars = value.asInstanceOf[String].getBytes(Charset.forName(DEFAULT_CHARSET))
       buffer.writeInt(chars.length)
       buffer.writeBytes(chars)
     } else {
-      sys.error(s"Unsupported field type $klass")
+      sys.error(s"Unsupported field type $clazz")
     }
   }
 
   /** Read value based on provided class */
-  def readValue(buffer: ByteBuf, klass: Class[_]): Any = {
-    if (klass == classOf[Byte]) {
+  def readValue(buffer: ByteBuf, clazz: Class[_]): Any = {
+    if (clazz == classOf[Byte]) {
       buffer.readByte()
-    } else if (klass == classOf[Short]) {
+    } else if (clazz == classOf[Short]) {
       buffer.readShort()
-    } else if (klass == classOf[Int]) {
+    } else if (clazz == classOf[Int]) {
       buffer.readInt()
-    } else if (klass == classOf[Long]) {
+    } else if (clazz == classOf[Long]) {
       buffer.readLong()
-    } else if (klass == classOf[String]) {
+    } else if (clazz == classOf[String]) {
       val length = buffer.readInt()
       val chars = new Array[Byte](length)
       buffer.readBytes(chars)
       new String(chars, Charset.forName(DEFAULT_CHARSET))
     } else {
-      sys.error(s"Unsupported field type $klass")
+      sys.error(s"Unsupported field type $clazz")
     }
   }
 
   /** Convert java class to closely matched scala class, otherwise return itself */
-  def javaToScala(klass: Class[_]): Class[_] = {
-    if (klass == classOf[java.lang.Byte]) {
+  def javaToScala(clazz: Class[_]): Class[_] = {
+    if (clazz == classOf[java.lang.Byte]) {
       classOf[Byte]
-    } else if (klass == classOf[java.lang.Short]) {
+    } else if (clazz == classOf[java.lang.Short]) {
       classOf[Short]
-    } else if (klass == classOf[java.lang.Integer]) {
+    } else if (clazz == classOf[java.lang.Integer]) {
       classOf[Int]
-    } else if (klass == classOf[java.lang.Long]) {
+    } else if (clazz == classOf[java.lang.Long]) {
       classOf[Long]
     } else {
-      klass
+      clazz
     }
   }
 
@@ -141,7 +141,7 @@ object StatisticsUtils {
    * Compare classes and return true, if both classes match either directly or with conversion,
    * otherwise false
    */
-  def softCompare(klass1: Class[_], klass2: Class[_]): Boolean = {
-    klass1 == klass2 || javaToScala(klass1) == javaToScala(klass2)
+  def softCompare(clazz1: Class[_], clazz2: Class[_]): Boolean = {
+    clazz1 == clazz2 || javaToScala(clazz1) == javaToScala(clazz2)
   }
 }

--- a/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsWriter.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/index/StatisticsWriter.scala
@@ -49,11 +49,11 @@ private[spark] class StatisticsWriter(
 
   /** Write attribute header (flags, name, etc). Exposed to a package for testing purposes */
   private[index] def writeAttributeHeader(
-      klass: Class[_], flags: Byte, key: String, hasNull: Boolean): Unit = {
+      clazz: Class[_], flags: Byte, key: String, hasNull: Boolean): Unit = {
     buffer.writeByte(StatisticsUtils.MAGIC_1)
     buffer.writeByte(StatisticsUtils.MAGIC_2)
     buffer.writeByte(flags)
-    buffer.writeByte(StatisticsUtils.getBytes(klass))
+    buffer.writeByte(StatisticsUtils.getBytes(clazz))
     buffer.writeBoolean(hasNull)
     // Bytes of the key based on charset, this will write length as integer and array of bytes
     StatisticsUtils.writeValue(buffer, key, classOf[String])
@@ -62,9 +62,9 @@ private[spark] class StatisticsWriter(
   /** Generic write method for arbitrary sequence of elements */
   private def writeElements(
       tpe: Byte,
-      klass: Class[_], size: Int, elems: GenTraversableOnce[_], hasNull: Boolean): Unit = {
+      clazz: Class[_], size: Int, elems: GenTraversableOnce[_], hasNull: Boolean): Unit = {
     buffer.writeByte(tpe)
-    buffer.writeByte(StatisticsUtils.getBytes(klass))
+    buffer.writeByte(StatisticsUtils.getBytes(clazz))
     buffer.writeInt(size)
     val iter = elems.toIterator
     while (iter.hasNext) {
@@ -74,14 +74,14 @@ private[spark] class StatisticsWriter(
       }
 
       if (!hasNull || elem != null) {
-        StatisticsUtils.writeValue(buffer, elem, klass)
+        StatisticsUtils.writeValue(buffer, elem, clazz)
       }
     }
   }
 
   private def writeElements(
-      tpe: Byte, klass: Class[_], elems: GenTraversableOnce[_], hasNull: Boolean): Unit = {
-    writeElements(tpe, klass, elems.size, elems, hasNull)
+      tpe: Byte, clazz: Class[_], elems: GenTraversableOnce[_], hasNull: Boolean): Unit = {
+    writeElements(tpe, clazz, elems.size, elems, hasNull)
   }
 
   /** Internal method to write single attribute. Exposed to a package for testing purposes */

--- a/src/main/scala/com/github/sadikovi/spark/netflow/sources/ResolvedInterface.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/sources/ResolvedInterface.scala
@@ -96,7 +96,7 @@ abstract class ResolvedInterface {
   }
 
   /** Resolve internal type into SQL type */
-  private[sources] def javaToSQLType(klass: Class[_]): DataType = klass match {
+  private[sources] def javaToSQLType(clazz: Class[_]): DataType = clazz match {
     case InternalType.BYTE => ByteType
     case InternalType.SHORT => ShortType
     case InternalType.INT => IntegerType


### PR DESCRIPTION
Very minor refactoring: replacing usage of `klass` with `clazz` which is a little bit more consistent with Spark.
