### PR TITLE
Use buffered input stream

### DIFF
--- a/src/main/java/com/github/sadikovi/netflowlib/Buffers.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/Buffers.java
@@ -16,6 +16,7 @@
 
 package com.github.sadikovi.netflowlib;
 
+import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
@@ -98,12 +99,13 @@ public final class Buffers {
       if (isCompressed) {
         inflater = new Inflater();
         // InflaterInputStream is replaced with ReadAheadInputStream to allow to resolve EOF before
-        // actual record reading
-        stream = new ReadAheadInputStream(in, inflater, bufferLength);
+        // actual record reading, we also wrap read ahead stream into buffered input stream
+        stream = new BufferedInputStream(
+          new ReadAheadInputStream(in, inflater, bufferLength), bufferLength);
         compression = true;
       } else {
         inflater = null;
-        stream = in;
+        stream = new BufferedInputStream(in);
         compression = false;
       }
 
@@ -199,7 +201,7 @@ public final class Buffers {
     // Reference to inflater to find out EOF mainly
     private final Inflater inflater;
     // Stream to read either standard DataInputStream or InflaterInputStream
-    private FilterInputStream stream;
+    private BufferedInputStream stream;
     // Primary array of bytes for a record
     private final byte[] primary;
     // Secondary array of bytes for a record, used when compression buffer needs to be refilled

--- a/src/main/scala/com/github/sadikovi/spark/benchmark/NetFlowReadBenchmark.scala
+++ b/src/main/scala/com/github/sadikovi/spark/benchmark/NetFlowReadBenchmark.scala
@@ -51,7 +51,7 @@ object NetFlowReadBenchmark {
 
   // Initialize Spark context
   val sparkConf = new SparkConf()
-  val sc = new SparkContext("local[*]", "test-sql-context", sparkConf)
+  val sc = new SparkContext("local[1]", "test-sql-context", sparkConf)
   val sqlContext = new SQLContext(sc)
 
   def main(args: Array[String]): Unit = {
@@ -66,9 +66,9 @@ object NetFlowReadBenchmark {
       sys.error("NetFlow version must be specified, e.g. '--version 5'"))
 
     // scalastyle:off
-    println(s"- Iterations: ${iterations}")
-    println(s"- Files: ${files}")
-    println(s"- Version: ${version}")
+    println(s"- Iterations: $iterations")
+    println(s"- Files: $files")
+    println(s"- Version: $version")
     // scalastyle:on
 
     // Defined benchmarks


### PR DESCRIPTION
This PR wraps standard Java input stream into buffered stream. This results on average in 30% performance improvements compared to master branch.

Benchmarks for full scan:

``` shell
Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
NetFlow full scan:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------
Scan, stringify = F                       481 /  564       2079.7       48084.8       1.0X
Scan, stringify = T                      1221 / 1272        818.9      122108.9       0.4X
```
