### PR TITLE
Add version resolution based on files provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Using statistics does not require any special conditions apart from enabling opt
 ```scala
 val sqlContext = new SQLContext(sc)
 
+// You can provide only format, package will infer version from provided files, or you can enforce
+// version of the files with `version` option.
+val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").load("...")
+
 // You can read files from local file system or HDFS
 val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
   option("version", "5").load("file:/...").
@@ -100,9 +104,6 @@ val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
 // You can also specify buffer size when reading compressed NetFlow files
 val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
   option("version", "5").option("buffer", "50Mb").load("hdfs://sandbox:8020/tmp/...")
-
-// You can also provide only format, it will infer version from provided files
-val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").load("...") 
 ```
 
 Alternatively you can use shortcuts for NetFlow files

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Currently supported options:
 
 | Name | Since | Example | Description |
 |------|:-----:|:-------:|-------------|
-| `version` | `0.0.1` | _5, 7_ | version to use when parsing NetFlow files, your own version provider can be passed
+| `version` | `0.0.1` | _5, 7_ | version to use when parsing NetFlow files, your own version provider can be passed, by default will resolve from files provided
 | `buffer` | `0.0.2` | _1024, 32Kb, 3Mb, etc_ | buffer size for NetFlow compressed stream (default: `1Mb`)
 | `stringify` | `0.0.2` | _true, false_ | convert certain fields (e.g. IP, protocol) into human-readable format, though it is recommended to turn it off when performance matters (default: `true`)
 | `predicate-pushdown` | `0.2.0` | _true, false_ | use predicate pushdown at NetFlow library level (default: `true`)
@@ -100,6 +100,9 @@ val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
 // You can also specify buffer size when reading compressed NetFlow files
 val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").
   option("version", "5").option("buffer", "50Mb").load("hdfs://sandbox:8020/tmp/...")
+
+// You can also provide only format, it will infer version from provided files
+val df = sqlContext.read.format("com.github.sadikovi.spark.netflow").load("...") 
 ```
 
 Alternatively you can use shortcuts for NetFlow files

--- a/src/main/scala/com/github/sadikovi/spark/netflow/package.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/package.scala
@@ -26,11 +26,13 @@ package object netflow {
    */
   implicit class NetFlowDataFrameReader(reader: DataFrameReader) {
     def netflow5: String => DataFrame = {
-      reader.format("com.github.sadikovi.spark.netflow").option("version", "5").load
+      reader.format("com.github.sadikovi.spark.netflow").
+        option("version", NetFlowRelation.VERSION_5).load
     }
 
     def netflow7: String => DataFrame = {
-      reader.format("com.github.sadikovi.spark.netflow").option("version", "7").load
+      reader.format("com.github.sadikovi.spark.netflow").
+        option("version", NetFlowRelation.VERSION_7).load
     }
   }
 }


### PR DESCRIPTION
PR adds ability to avoid specifying version for every read. Code will read first file and read header from it. If no files provided version 5 is selected (in this case version does not really matter).

Also PR adds/refactors more tests. 