### PR TITLE
Use nio direct buffer input stream for local fs

### DIFF
--- a/src/main/java/com/github/sadikovi/netflowlib/NetFlowReader.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/NetFlowReader.java
@@ -16,7 +16,7 @@
 
 package com.github.sadikovi.netflowlib;
 
-import java.io.DataInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.HashMap;
@@ -42,6 +42,7 @@ import com.github.sadikovi.netflowlib.version.NetFlow;
 import com.github.sadikovi.netflowlib.version.NetFlowV5;
 import com.github.sadikovi.netflowlib.version.NetFlowV7;
 
+import com.github.sadikovi.netflowlib.util.NioBufferedFileInputStream;
 import com.github.sadikovi.netflowlib.util.Logging;
 
 /**
@@ -63,7 +64,7 @@ public final class NetFlowReader extends Logging {
   private static final short HEADER_BIG_ENDIAN = 2;
 
   public static NetFlowReader prepareReader(
-      DataInputStream inputStream,
+      InputStream inputStream,
       int buffer) throws IOException {
     return new NetFlowReader(inputStream, buffer);
   }
@@ -73,7 +74,7 @@ public final class NetFlowReader extends Logging {
    * strategy based on columns, predicate and statistics. Metadata, header are parsed as part of
    * initialization.
    */
-  private NetFlowReader(DataInputStream inputStream, int buffer) throws IOException {
+  private NetFlowReader(InputStream inputStream, int buffer) throws IOException {
     in = inputStream;
     bufferLength = buffer;
 
@@ -440,7 +441,7 @@ public final class NetFlowReader extends Logging {
   }
 
   // Stream of the NetFlow file
-  private final DataInputStream in;
+  private final InputStream in;
   // Byte order of the file
   private final ByteOrder byteOrder;
   // Stream version of the file

--- a/src/main/java/com/github/sadikovi/netflowlib/util/NioBufferedFileInputStream.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/util/NioBufferedFileInputStream.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.netflowlib.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+
+import sun.nio.ch.DirectBuffer;
+
+/**
+ * {@link InputStream} implementation which uses direct buffer
+ * to read a file to avoid extra copy of data between Java and
+ * native memory which happens when using {@link java.io.BufferedInputStream}.
+ * Unfortunately, this is not something already available in JDK,
+ * {@link sun.nio.ch.ChannelInputStream} supports reading a file using nio,
+ * but does not support buffering.
+ */
+public final class NioBufferedFileInputStream extends InputStream {
+
+  public static final int DEFAULT_BUFFER_SIZE_BYTES = 8192;
+
+  private final ByteBuffer byteBuffer;
+
+  private final FileChannel fileChannel;
+
+  public NioBufferedFileInputStream(File file, int bufferSizeInBytes) throws IOException {
+    byteBuffer = ByteBuffer.allocateDirect(bufferSizeInBytes);
+    fileChannel = FileChannel.open(file.toPath(), StandardOpenOption.READ);
+    byteBuffer.flip();
+  }
+
+  public NioBufferedFileInputStream(File file) throws IOException {
+    this(file, DEFAULT_BUFFER_SIZE_BYTES);
+  }
+
+  /**
+   * Checks weather data is left to be read from the input stream.
+   * @return true if data is left, false otherwise
+   * @throws IOException
+   */
+  private boolean refill() throws IOException {
+    if (!byteBuffer.hasRemaining()) {
+      byteBuffer.clear();
+      int nRead = 0;
+      while (nRead == 0) {
+        nRead = fileChannel.read(byteBuffer);
+      }
+      if (nRead < 0) {
+        return false;
+      }
+      byteBuffer.flip();
+    }
+    return true;
+  }
+
+  @Override
+  public synchronized int read() throws IOException {
+    if (!refill()) {
+      return -1;
+    }
+    return byteBuffer.get() & 0xFF;
+  }
+
+  @Override
+  public synchronized int read(byte[] b, int offset, int len) throws IOException {
+    if (offset < 0 || len < 0 || offset + len < 0 || offset + len > b.length) {
+      throw new IndexOutOfBoundsException();
+    }
+    if (!refill()) {
+      return -1;
+    }
+    len = Math.min(len, byteBuffer.remaining());
+    byteBuffer.get(b, offset, len);
+    return len;
+  }
+
+  @Override
+  public synchronized int available() throws IOException {
+    return byteBuffer.remaining();
+  }
+
+  @Override
+  public synchronized long skip(long n) throws IOException {
+    if (n <= 0L) {
+      return 0L;
+    }
+    if (byteBuffer.remaining() >= n) {
+      // The buffered content is enough to skip
+      byteBuffer.position(byteBuffer.position() + (int) n);
+      return n;
+    }
+    long skippedFromBuffer = byteBuffer.remaining();
+    long toSkipFromFileChannel = n - skippedFromBuffer;
+    // Discard everything we have read in the buffer.
+    byteBuffer.position(0);
+    byteBuffer.flip();
+    return skippedFromBuffer + skipFromFileChannel(toSkipFromFileChannel);
+  }
+
+  private long skipFromFileChannel(long n) throws IOException {
+    long currentFilePosition = fileChannel.position();
+    long size = fileChannel.size();
+    if (n > size - currentFilePosition) {
+      fileChannel.position(size);
+      return size - currentFilePosition;
+    } else {
+      fileChannel.position(currentFilePosition + n);
+      return n;
+    }
+  }
+
+  @Override
+  public synchronized void close() throws IOException {
+    fileChannel.close();
+    dispose(byteBuffer);
+  }
+
+  private void dispose(ByteBuffer buffer) {
+    if (buffer != null && buffer instanceof MappedByteBuffer) {
+      DirectBuffer directBuffer = (DirectBuffer) buffer;
+      if (directBuffer.cleaner() != null) {
+        directBuffer.cleaner().clean();
+      }
+    }
+  }
+
+  @Override
+  protected void finalize() throws IOException {
+    close();
+  }
+}

--- a/src/main/scala/com/github/sadikovi/spark/netflow/NetFlowRelation.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/NetFlowRelation.scala
@@ -118,6 +118,14 @@ private[netflow] class NetFlowRelation(
   }
   logger.info(s"Statistics: $statisticsStatus")
 
+  // Whether or not use nio direct buffers when reading file, only applied to local file system,
+  // does not take effect for HDFS
+  private[netflow] val useDirectBuffer = parameters.get("nio") match {
+    case Some("true") => true
+    case otherValue => false
+  }
+  logger.info(s"Use direct buffer [experimental]: $useDirectBuffer")
+
   // Get currently parsed interface, mostly for testing
   private[netflow] def getInterface(): String = interface.getClass.getName
 
@@ -247,7 +255,7 @@ private[netflow] class NetFlowRelation(
 
       // Return `NetFlowFileRDD`, we store data of each file based on provided partition mode
       new NetFlowFileRDD(sqlContext.sparkContext, fileStatuses, partitionMode, applyConversion,
-        resolvedColumns, resolvedFilter, statisticsIndex)
+        resolvedColumns, resolvedFilter, statisticsIndex, useDirectBuffer)
     }
   }
 


### PR DESCRIPTION
This PR adds boolean option `nio` to select nio direct buffers input stream to read local files. This work is similar to Spark PR 15408. By default, current implementation is used.