### PR TITLE
Close iterator on task completion

### DIFF
--- a/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
+++ b/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
@@ -168,6 +168,7 @@ private[spark] class NetFlowFileRDD[T <: SQLRow : ClassTag] (
           }
         }
       }
+      Option(TaskContext.get).foreach(_.addTaskCompletionListener(_ => rawIterator.closeIfNeeded))
 
       // Try collecting statistics before any other mode, because attributes collect raw data. If
       // file exists, it is assumed that statistics are already written


### PR DESCRIPTION
This PR adds listener on task completion to close iterator of records. This is in addition to work for introducing `CloseableIterator` in #48.