### PR TITLE
Option to ignore corrupt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ specified when selecting data, columns that are selected contain all statistics 
 all data is scanned/requested. The easiest way to trigger that is running `count()` on DataFrame.
 Using statistics does not require any special conditions apart from enabling option.
 
+### Dealing with corrupt files
+Package supports Spark option `spark.files.ignoreCorruptFiles`. When set to `true`, corrupt files
+are ignored (corrupt header, wrong format) or partially read (corrupt data block in a middle of a
+file). By default option is set to `false`, similar to Spark.
+
 ## Example
 
 ### Scala API

--- a/src/test/scala/com/github/sadikovi/spark/netflow/NetFlowSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/NetFlowSuite.scala
@@ -26,8 +26,6 @@ import org.apache.spark.sql.{SQLContext, DataFrame, Row}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.sources._
 
-import org.scalatest.ConfigMap
-
 import com.github.sadikovi.netflowlib.Buffers.RecordBuffer
 import com.github.sadikovi.netflowlib.version.NetFlowV5
 import com.github.sadikovi.spark.netflow.sources._
@@ -37,11 +35,11 @@ import com.github.sadikovi.testutil.{UnitTestSpec, SparkLocal}
 import com.github.sadikovi.testutil.implicits._
 
 class NetFlowSuite extends UnitTestSpec with SparkLocal {
-  override def beforeAll(configMap: ConfigMap) {
+  override def beforeAll() {
     startSparkContext()
   }
 
-  override def afterAll(configMap: ConfigMap) {
+  override def afterAll() {
     stopSparkContext()
   }
 


### PR DESCRIPTION
This PR updates `NetFlowFileRDD` to respect Spark option `spark.files.ignoreCorruptFiles`. When this Spark option is `true`, files that are corrupt or not NetFlow files are ignored. If file partially corrupt, then only recoverable data is read (up to corrupted block), if reader fails to initialize, then empty iterator is returned from that file.