### PR TITLE
Ignore corrupt files 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ specified when selecting data, columns that are selected contain all statistics 
 all data is scanned/requested. The easiest way to trigger that is running `count()` on DataFrame.
 Using statistics does not require any special conditions apart from enabling option.
 
+### Dealing with corrupt files
+Package supports Spark option `spark.files.ignoreCorruptFiles`. When set to `true`, corrupt files
+are ignored (corrupt header, wrong format) or partially read (corrupt data block in a middle of a
+file). By default option is set to `false`, similar to Spark.
+
 ## Example
 
 ### Scala API

--- a/src/main/java/com/github/sadikovi/netflowlib/CorruptNetFlowHeader.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/CorruptNetFlowHeader.java
@@ -18,9 +18,6 @@ package com.github.sadikovi.netflowlib;
 
 import java.nio.ByteOrder;
 
-import com.github.sadikovi.netflowlib.fields.InterfaceAlias;
-import com.github.sadikovi.netflowlib.fields.InterfaceName;
-
 /** Class to indicate that header is corrupt */
 public class CorruptNetFlowHeader extends NetFlowHeader {
   public CorruptNetFlowHeader() {

--- a/src/main/java/com/github/sadikovi/netflowlib/CorruptNetFlowHeader.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/CorruptNetFlowHeader.java
@@ -187,49 +187,4 @@ public class CorruptNetFlowHeader extends NetFlowHeader {
   public long getFields() {
     throw new UnsupportedOperationException("Header is corrupt");
   }
-
-  // bit vector of fields
-  private long FIELDS = 0;
-  // flow stream format version either 1 or 3
-  private short sversion = 0;
-  // byte order, either big endian or little endian
-  private ByteOrder order = null;
-  // actual header size (will be different in case of stream version 3)
-  private int headerSize = 0;
-  // version of NetFlow
-  private short dversion = 0;
-  // start time of flow capture
-  private long start = 0;
-  // end time of flow capture
-  private long end = 0;
-  // header flags as bit vector
-  private long flags = 0;
-  // rotation schedule
-  private long rotation = 0;
-  // number of flows
-  private long numFlows = 0;
-  // number of dropped packets (stream version 1) / flows (stream version 3)
-  private long numDropped = 0;
-  // number of misordered packets (stream version 1) / flows (stream version 3)
-  private long numMisordered = 0;
-  // name of capture device
-  private String hostname = null;
-  // ascii comments
-  private String comments = null;
-  // vendor (cisco - 0x1)
-  private int vendor = 0;
-  // aggregation version
-  private short aggregationVersion = 0;
-  // aggregation method
-  private short aggregationMethod = 0;
-  // exporter IP
-  private long exporterIP = 0;
-  // number of corrupt packets (stream version 1) / flows (stream version 3)
-  private long numCorrupt = 0;
-  // times sequence # was so far off lost/misordered state could not be determined
-  private long seqReset = 0;
-  // interface name
-  private InterfaceName interfaceName = null;
-  // interface alias
-  private InterfaceAlias interfaceAlias = null;
 }

--- a/src/main/java/com/github/sadikovi/netflowlib/CorruptNetFlowHeader.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/CorruptNetFlowHeader.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.netflowlib;
+
+import java.nio.ByteOrder;
+
+import com.github.sadikovi.netflowlib.fields.InterfaceAlias;
+import com.github.sadikovi.netflowlib.fields.InterfaceName;
+
+/** Class to indicate that header is corrupt */
+public class CorruptNetFlowHeader extends NetFlowHeader {
+  public CorruptNetFlowHeader() {
+    this.isValid = false;
+  }
+
+  ////////////////////////////////////////////////////////////
+  // Setters API
+  ////////////////////////////////////////////////////////////
+  @Override
+  public void setFlowVersion(short version) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setStartCapture(long value) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setEndCapture(long value) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setHeaderFlags(long flags) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setRotation(long value) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setNumFlows(long value) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setNumDropped(long value) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setNumMisordered(long value) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setHostname(String hostname) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setComments(String comments) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setVendor(int value) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setAggVersion(short value) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setAggMethod(short value) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setExporterIP(long value) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setNumCorrupt(long value) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setSeqReset(long value) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setInterfaceName(long ip, int ifIndex, String name) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public void setInterfaceAlias(long ip, int ifIndexCount, int ifIndex, String alias) {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  ////////////////////////////////////////////////////////////
+  // Getters API
+  ////////////////////////////////////////////////////////////
+  @Override
+  public short getStreamVersion() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public ByteOrder getByteOrder() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public int getHeaderSize() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public short getFlowVersion() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public long getStartCapture() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public long getEndCapture() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public long getHeaderFlags() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public boolean isCompressed() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public String getHostname() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public String getComments() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public short getAggMethod() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public short getAggVersion() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public long getFields() {
+    throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  // bit vector of fields
+  private long FIELDS = 0;
+  // flow stream format version either 1 or 3
+  private short sversion = 0;
+  // byte order, either big endian or little endian
+  private ByteOrder order = null;
+  // actual header size (will be different in case of stream version 3)
+  private int headerSize = 0;
+  // version of NetFlow
+  private short dversion = 0;
+  // start time of flow capture
+  private long start = 0;
+  // end time of flow capture
+  private long end = 0;
+  // header flags as bit vector
+  private long flags = 0;
+  // rotation schedule
+  private long rotation = 0;
+  // number of flows
+  private long numFlows = 0;
+  // number of dropped packets (stream version 1) / flows (stream version 3)
+  private long numDropped = 0;
+  // number of misordered packets (stream version 1) / flows (stream version 3)
+  private long numMisordered = 0;
+  // name of capture device
+  private String hostname = null;
+  // ascii comments
+  private String comments = null;
+  // vendor (cisco - 0x1)
+  private int vendor = 0;
+  // aggregation version
+  private short aggregationVersion = 0;
+  // aggregation method
+  private short aggregationMethod = 0;
+  // exporter IP
+  private long exporterIP = 0;
+  // number of corrupt packets (stream version 1) / flows (stream version 3)
+  private long numCorrupt = 0;
+  // times sequence # was so far off lost/misordered state could not be determined
+  private long seqReset = 0;
+  // interface name
+  private InterfaceName interfaceName = null;
+  // interface alias
+  private InterfaceAlias interfaceAlias = null;
+}

--- a/src/main/java/com/github/sadikovi/netflowlib/CorruptNetFlowHeader.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/CorruptNetFlowHeader.java
@@ -18,11 +18,12 @@ package com.github.sadikovi.netflowlib;
 
 import java.nio.ByteOrder;
 
-/** Class to indicate that header is corrupt */
+/**
+ * Class to indicate that header is corrupt. Overwrites parent method `isValid()` to hint on
+ * incorrectness of header.
+ */
 public class CorruptNetFlowHeader extends NetFlowHeader {
-  public CorruptNetFlowHeader() {
-    this.isValid = false;
-  }
+  public CorruptNetFlowHeader() { }
 
   ////////////////////////////////////////////////////////////
   // Setters API
@@ -183,5 +184,10 @@ public class CorruptNetFlowHeader extends NetFlowHeader {
   @Override
   public long getFields() {
     throw new UnsupportedOperationException("Header is corrupt");
+  }
+
+  @Override
+  public boolean isValid() {
+    return false;
   }
 }

--- a/src/main/java/com/github/sadikovi/netflowlib/NetFlowHeader.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/NetFlowHeader.java
@@ -260,8 +260,12 @@ public class NetFlowHeader {
     return this.FIELDS;
   }
 
+  /**
+   * By default standard NetFlow header is always valid. Subclasses should overwrite this method,
+   * if that is not the case, or method should be conditional.
+   */
   public boolean isValid() {
-    return this.isValid;
+    return true;
   }
 
   // bit vector of fields
@@ -308,6 +312,4 @@ public class NetFlowHeader {
   private InterfaceName interfaceName = null;
   // interface alias
   private InterfaceAlias interfaceAlias = null;
-  // whether or not header is valid
-  protected boolean isValid = true;
 }

--- a/src/main/java/com/github/sadikovi/netflowlib/NetFlowHeader.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/NetFlowHeader.java
@@ -75,6 +75,9 @@ public class NetFlowHeader {
     this.headerSize = headerSize;
   }
 
+  /** For subclasses to overwrite */
+  protected NetFlowHeader() { }
+
   ////////////////////////////////////////////////////////////
   // Setters API
   ////////////////////////////////////////////////////////////
@@ -257,6 +260,10 @@ public class NetFlowHeader {
     return this.FIELDS;
   }
 
+  public boolean isValid() {
+    return this.isValid;
+  }
+
   // bit vector of fields
   private long FIELDS = 0;
   // flow stream format version either 1 or 3
@@ -301,4 +308,6 @@ public class NetFlowHeader {
   private InterfaceName interfaceName = null;
   // interface alias
   private InterfaceAlias interfaceAlias = null;
+  // whether or not header is valid
+  protected boolean isValid = true;
 }

--- a/src/main/java/com/github/sadikovi/netflowlib/NetFlowReader.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/NetFlowReader.java
@@ -500,7 +500,9 @@ public final class NetFlowReader {
   }
 
   /**
-   * Whether or not reader is valid. Note that it returns null header, if reader is invalid.
+   * Whether or not reader is valid, currently is based on validity of header, assuming that file
+   * is of correct format, but might still have corrupt data blocks. See buffers implementation for
+   * usage of `ignoreCorrupt`.
    */
   public boolean isValid() {
     return header.isValid();

--- a/src/main/java/com/github/sadikovi/netflowlib/NetFlowReader.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/NetFlowReader.java
@@ -156,7 +156,8 @@ public final class NetFlowReader {
     } catch (Exception err) {
       if (ignoreCorrupt) {
         // we subsume exception and log warning. Set header to null
-        log.warn("Failed to initialize reader, ignoreCorruptFile=" + ignoreCorrupt, err);
+        log.warn("Failed to initialize reader, ignoreCorruptFile=" + ignoreCorrupt +
+          ", error=" + err);
         header = new CorruptNetFlowHeader();
       } else {
         throw err;

--- a/src/main/java/com/github/sadikovi/netflowlib/NetFlowReader.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/NetFlowReader.java
@@ -134,7 +134,7 @@ public final class NetFlowReader {
       // Verify consistency of NetFlow file, also this ensures that we are at the beginning of the
       // input stream
       if (magic1 != HEADER_MAGIC1 || magic2 != HEADER_MAGIC2) {
-        throw new UnsupportedOperationException("Corrupt NetFlow file. Wrong magic number");
+        throw new IOException("Corrupt NetFlow file. Wrong magic number");
       }
 
       // Resolve byte order, last case corresponds to incorrect reading from buffer
@@ -143,7 +143,7 @@ public final class NetFlowReader {
       } else if (order == HEADER_LITTLE_ENDIAN) {
         byteOrder = ByteOrder.LITTLE_ENDIAN;
       } else {
-        throw new UnsupportedOperationException("Could not recognize byte order " + order);
+        throw new IOException("Could not recognize byte order " + order);
       }
 
       streamVersion = stream;
@@ -153,7 +153,7 @@ public final class NetFlowReader {
 
       // Read header
       header = getHeader();
-    } catch (Exception err) {
+    } catch (IOException err) {
       if (ignoreCorrupt) {
         // we subsume exception and log warning. Set header to null
         log.warn("Failed to initialize reader, ignoreCorruptFile=" + ignoreCorrupt +

--- a/src/main/java/com/github/sadikovi/netflowlib/util/FilterIterator.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/util/FilterIterator.java
@@ -25,7 +25,7 @@ import java.util.NoSuchElementException;
  * internal methods to provide original stream of values. When iterator is called, standard methods
  * will be called with filter already.
  */
-public final class FilterIterator<E> implements Iterator<E> {
+public class FilterIterator<E> implements Iterator<E> {
   public FilterIterator(Iterator<E> iterator) {
     this.iterator = iterator;
   }

--- a/src/main/java/com/github/sadikovi/netflowlib/util/SafeIterator.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/util/SafeIterator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.netflowlib.util;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Iterator implementation that terminates delegate iterator when exception occurs during value
+ * extraction.
+ */
+public final class SafeIterator<E> implements Iterator<E> {
+  private boolean gotNext = false;
+  private E nextValue = null;
+  protected boolean finished = false;
+  private Iterator<E> delegate;
+
+  public SafeIterator(Iterator<E> delegate) {
+    this.delegate = delegate;
+  }
+
+  /**
+   * If no next element is available, `finished` is set to `true` and may return any value
+   * (it will be ignored). This convention is required because `null` may be a valid value.
+   * @return E instance, or set 'finished' to `true` when done
+   */
+  private E getNext() {
+    try {
+      if (delegate.hasNext()) {
+        return delegate.next();
+      } else {
+        finished = true;
+        return null;
+      }
+    } catch (Exception err) {
+      finished = true;
+      return null;
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (!finished) {
+      if (!gotNext) {
+        nextValue = getNext();
+        gotNext = true;
+      }
+    }
+    return !finished;
+  }
+
+  @Override
+  public E next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException("End of stream");
+    }
+    gotNext = false;
+    return nextValue;
+  }
+}

--- a/src/main/java/com/github/sadikovi/netflowlib/util/SafeIterator.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/util/SafeIterator.java
@@ -23,7 +23,7 @@ import java.util.NoSuchElementException;
  * Iterator implementation that terminates delegate iterator when exception occurs during value
  * extraction.
  */
-public final class SafeIterator<E> implements Iterator<E> {
+public class SafeIterator<E> implements Iterator<E> {
   private boolean gotNext = false;
   private E nextValue = null;
   protected boolean finished = false;
@@ -70,5 +70,10 @@ public final class SafeIterator<E> implements Iterator<E> {
     }
     gotNext = false;
     return nextValue;
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException("Operation 'remove' is not supported");
   }
 }

--- a/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
+++ b/src/main/scala/com/github/sadikovi/spark/rdd/NetFlowFileRDD.scala
@@ -68,7 +68,7 @@ private[spark] class NetFlowFileRDD[T <: SQLRow : ClassTag] (
     val resolvedFilter: Option[FilterPredicate],
     val statisticsIndex: Map[Int, MappedColumn]) extends FileRDD[SQLRow](sc, Nil) {
   // when true, ignore corrupt files, either with wrong header or corrupt data block
-  private val ignoreCorruptFiles = sc.getConf.getBoolean("spark.files.ignoreCorruptFiles", false);
+  private val ignoreCorruptFiles = sc.getConf.getBoolean("spark.files.ignoreCorruptFiles", false)
 
   override def getPartitions: Array[Partition] = {
     val slices = partitionMode.tryToPartition(data)

--- a/src/test/java/com/github/sadikovi/netflowlib/NetFlowHeaderSuite.java
+++ b/src/test/java/com/github/sadikovi/netflowlib/NetFlowHeaderSuite.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.netflowlib;
+
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.junit.Test;
+import org.junit.Ignore;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
+
+import com.github.sadikovi.netflowlib.CorruptNetFlowHeader;
+import com.github.sadikovi.netflowlib.NetFlowHeader;
+
+public class NetFlowHeaderSuite {
+  @Test
+  public void testInitNetFlowHeader() {
+    NetFlowHeader header = new NetFlowHeader((short) 5, ByteOrder.BIG_ENDIAN);
+    assertEquals(header.getStreamVersion(), 5);
+    assertEquals(header.getByteOrder(), ByteOrder.BIG_ENDIAN);
+    assertEquals(header.isValid(), true);
+  }
+
+  @Test
+  public void testInitCorruptNetFlowHeader() {
+    NetFlowHeader header = new CorruptNetFlowHeader();
+    assertEquals(header.isValid(), false);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testFailOnCorruptHeaderMethod1() {
+    NetFlowHeader header = new CorruptNetFlowHeader();
+    header.getStreamVersion();
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testFailOnCorruptHeaderMethod2() {
+    NetFlowHeader header = new CorruptNetFlowHeader();
+    header.getByteOrder();
+  }
+}

--- a/src/test/java/com/github/sadikovi/netflowlib/NetFlowReaderSuite.java
+++ b/src/test/java/com/github/sadikovi/netflowlib/NetFlowReaderSuite.java
@@ -73,6 +73,16 @@ public class NetFlowReaderSuite {
     }
   }
 
+  // test reader on corrupt input, should not fail
+  @Test
+  public void testReadingCorruptWithIgnoreCorrupt() throws IOException {
+    String file = getClass().getResource("/corrupt/ftv5.2016-01-13.compress.9.sample-01").getPath();
+    FSDataInputStream stm = getTestStream(file);
+
+    NetFlowReader nr = NetFlowReader.prepareReader(stm, 30000, true);
+    assertEquals(nr.isValid(), false);
+  }
+
   @Test
   public void testReadingCompressed() throws IOException {
     String file = getClass().
@@ -82,6 +92,7 @@ public class NetFlowReaderSuite {
     NetFlowReader nr = NetFlowReader.prepareReader(stm, 30000);
     NetFlowHeader header = nr.getHeader();
 
+    assertEquals(nr.isValid(), true);
     assertEquals(header.getFlowVersion(), (short) 7);
     assertEquals(header.isCompressed(), true);
     assertEquals(header.getStartCapture(), 0L);
@@ -103,6 +114,7 @@ public class NetFlowReaderSuite {
     NetFlowReader nr = NetFlowReader.prepareReader(stm, 30000);
     NetFlowHeader header = nr.getHeader();
 
+    assertEquals(nr.isValid(), true);
     assertEquals(header.getFlowVersion(), (short) 5);
     assertEquals(header.isCompressed(), false);
     assertEquals(header.getStartCapture(), 0L);
@@ -124,6 +136,7 @@ public class NetFlowReaderSuite {
     NetFlowReader nr = NetFlowReader.prepareReader(stm, 30000);
     NetFlowHeader header = nr.getHeader();
 
+    assertEquals(nr.isValid(), true);
     assertEquals(header.getFlowVersion(), (short) 5);
     assertEquals(header.isCompressed(), false);
     assertEquals(header.getStartCapture(), 0L);
@@ -145,6 +158,7 @@ public class NetFlowReaderSuite {
     NetFlowReader nr = NetFlowReader.prepareReader(stm, 30000);
     NetFlowHeader header = nr.getHeader();
 
+    assertEquals(nr.isValid(), true);
     assertEquals(header.getFlowVersion(), (short) 5);
     assertEquals(header.isCompressed(), true);
     assertEquals(header.getStartCapture(), 0L);

--- a/src/test/java/com/github/sadikovi/netflowlib/NetFlowReaderSuite.java
+++ b/src/test/java/com/github/sadikovi/netflowlib/NetFlowReaderSuite.java
@@ -68,8 +68,8 @@ public class NetFlowReaderSuite {
 
     try {
       NetFlowReader nr = NetFlowReader.prepareReader(stm, 30000);
-    } catch (UnsupportedOperationException uoe) {
-      assertThat(uoe.getMessage(), containsString("Corrupt NetFlow file. Wrong magic number"));
+    } catch (IOException ioe) {
+      assertThat(ioe.getMessage(), containsString("Corrupt NetFlow file. Wrong magic number"));
     }
   }
 

--- a/src/test/java/com/github/sadikovi/netflowlib/UtilSuite.java
+++ b/src/test/java/com/github/sadikovi/netflowlib/UtilSuite.java
@@ -113,7 +113,7 @@ public class UtilSuite {
 
   @Test
   public void testSafeIteratorTerminateOnErrorInHasNext() {
-    List<String> values = new ArrayList<String>();
+    final List<String> values = new ArrayList<String>();
     values.add("a");
     values.add(null);
     values.add("a");
@@ -134,6 +134,9 @@ public class UtilSuite {
       public String next() {
         return current;
       }
+
+      @Override
+      public void remove() { }
     };
     SafeIterator<String> iter = new SafeIterator<String>(delegate);
 
@@ -149,7 +152,7 @@ public class UtilSuite {
 
   @Test
   public void testSafeIteratorTerminateOnErrorInNext() {
-    List<String> values = new ArrayList<String>();
+    final List<String> values = new ArrayList<String>();
     values.add("a");
     values.add(null);
     values.add("a");
@@ -165,6 +168,9 @@ public class UtilSuite {
       public String next() {
         return parent.next().toString();
       }
+
+      @Override
+      public void remove() { }
     };
     SafeIterator<String> iter = new SafeIterator<String>(delegate);
 

--- a/src/test/java/com/github/sadikovi/netflowlib/UtilSuite.java
+++ b/src/test/java/com/github/sadikovi/netflowlib/UtilSuite.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.netflowlib;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.junit.Test;
+import org.junit.Ignore;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
+
+import com.github.sadikovi.netflowlib.util.FilterIterator;
+import com.github.sadikovi.netflowlib.util.SafeIterator;
+
+public class UtilSuite {
+  @Test(expected = NoSuchElementException.class)
+  public void testFilterIteratorFailIfEmpty() {
+    List<String> values = new ArrayList<String>();
+    FilterIterator<String> iter = new FilterIterator<String>(values.iterator());
+    iter.next();
+  }
+
+  @Test
+  public void testFilterIteratorReturnAll() {
+    List<String> values = new ArrayList<String>();
+    values.add("a");
+    values.add("a");
+    values.add("a");
+    FilterIterator<String> iter = new FilterIterator<String>(values.iterator());
+
+    int count = 0;
+    while (iter.hasNext()) {
+      assertSame(iter.next(), "a");
+      count++;
+    }
+
+    assertEquals(count, values.size());
+  }
+
+  @Test
+  public void testFilterIteratorReturnSome() {
+    List<String> values = new ArrayList<String>();
+    values.add("a");
+    values.add(null);
+    values.add("a");
+    FilterIterator<String> iter = new FilterIterator<String>(values.iterator());
+
+    int count = 0;
+    while (iter.hasNext()) {
+      assertSame(iter.next(), "a");
+      count++;
+    }
+
+    assertEquals(count, 2);
+  }
+
+  @Test
+  public void testFilterIteratorReturnNone() {
+    List<String> values = new ArrayList<String>();
+    values.add(null);
+    values.add(null);
+    values.add(null);
+    FilterIterator<String> iter = new FilterIterator<String>(values.iterator());
+
+    int count = 0;
+    while (iter.hasNext()) {
+      count++;
+    }
+
+    assertEquals(count, 0);
+  }
+
+  @Test(expected = NoSuchElementException.class)
+  public void testSafeIteratorFailIfEmpty() {
+    List<String> values = new ArrayList<String>();
+    SafeIterator<String> iter = new SafeIterator<String>(values.iterator());
+    iter.next();
+  }
+
+  @Test
+  public void testSafeIteratorReturnAll() {
+    List<String> values = new ArrayList<String>();
+    values.add("a");
+    values.add("a");
+    values.add("a");
+    SafeIterator<String> iter = new SafeIterator<String>(values.iterator());
+
+    int count = 0;
+    while (iter.hasNext()) {
+      assertSame(iter.next(), "a");
+      count++;
+    }
+
+    assertEquals(count, values.size());
+  }
+
+  @Test
+  public void testSafeIteratorTerminateOnErrorInHasNext() {
+    List<String> values = new ArrayList<String>();
+    values.add("a");
+    values.add(null);
+    values.add("a");
+    Iterator<String> delegate = new Iterator() {
+      private Iterator<String> parent = values.iterator();
+      private String current;
+
+      @Override
+      public boolean hasNext() {
+        current = parent.next();
+        if (current == null) {
+          throw new IllegalStateException("Test");
+        }
+        return parent.hasNext();
+      }
+
+      @Override
+      public String next() {
+        return current;
+      }
+    };
+    SafeIterator<String> iter = new SafeIterator<String>(delegate);
+
+    int count = 0;
+    while (iter.hasNext()) {
+      assertSame(iter.next(), "a");
+      count++;
+    }
+
+    // Expect one record only, since second record fails with state exception
+    assertEquals(count, 1);
+  }
+
+  @Test
+  public void testSafeIteratorTerminateOnErrorInNext() {
+    List<String> values = new ArrayList<String>();
+    values.add("a");
+    values.add(null);
+    values.add("a");
+    Iterator<String> delegate = new Iterator() {
+      private Iterator<String> parent = values.iterator();
+
+      @Override
+      public boolean hasNext() {
+        return parent.hasNext();
+      }
+
+      @Override
+      public String next() {
+        return parent.next().toString();
+      }
+    };
+    SafeIterator<String> iter = new SafeIterator<String>(delegate);
+
+    int count = 0;
+    while (iter.hasNext()) {
+      assertSame(iter.next(), "a");
+      count++;
+    }
+
+    // Expect one record only, since second record fails with null pointer exception
+    assertEquals(count, 1);
+  }
+}

--- a/src/test/scala/com/github/sadikovi/spark/netflow/NetFlowSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/NetFlowSuite.scala
@@ -157,7 +157,7 @@ class NetFlowSuite extends SparkNetFlowTestSuite {
         load(s"file:${path3}").count()
     }
     val msg = err.getMessage()
-    assert(msg.contains("java.lang.UnsupportedOperationException: " +
+    assert(msg.contains("java.io.IOException: " +
       "Corrupt NetFlow file. Wrong magic number"))
   }
 

--- a/src/test/scala/com/github/sadikovi/testutil/SparkBase.scala
+++ b/src/test/scala/com/github/sadikovi/testutil/SparkBase.scala
@@ -23,8 +23,13 @@ import org.apache.spark.{SparkContext, SparkConf}
 private[testutil] trait SparkBase {
   @transient private[testutil] var _sc: SparkContext = null
 
-  /** Start (or init) Spark context. */
+  /** Initialize Spark context with default parameters */
   def startSparkContext() {
+    startSparkContext(Map.empty)
+  }
+
+  /** Start (or init) Spark context. */
+  def startSparkContext(sparkOptions: Map[String, String]) {
     // stop previous Spark context
     stopSparkContext()
     _sc = new SparkContext()

--- a/src/test/scala/com/github/sadikovi/testutil/SparkLocal.scala
+++ b/src/test/scala/com/github/sadikovi/testutil/SparkLocal.scala
@@ -31,9 +31,12 @@ trait SparkLocal extends SparkBase {
       set("spark.executor.memory", "2g")
   }
 
-  override def startSparkContext() {
+  override def startSparkContext(sparkOptions: Map[String, String]) {
     setLoggingLevel(Level.ERROR)
     val conf = localConf()
+    sparkOptions.foreach { case (key, value) =>
+      conf.set(key, value)
+    }
     _sc = new SparkContext(conf)
   }
 }


### PR DESCRIPTION
This PR takes more general approach of introducing `ignoreCorruptFiles`. It updates NetFlowFileRDD to respect Spark option `spark.files.ignoreCorruptFiles`. When this Spark option is true, files that are corrupt or not NetFlow files are ignored. If file partially corrupt, then only recoverable data is read (up to corrupted block), if reader fails to initialize, then empty iterator is returned from that file.

This change is also added to `netflowlib`, so reader can take option `ignoreCorruptFiles` (default is `false`) and, in case of failure, sets `isValid()` to false, and returns `CorruptNetFlowHeader`, which is no-op for most of the operations. When flag is true, `SafeIterator` is returned, that terminates on failure.