### PR TITLE
Add error message when failed to infer version

### DIFF
--- a/src/main/scala/com/github/sadikovi/spark/netflow/DefaultSource.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/DefaultSource.scala
@@ -16,6 +16,8 @@
 
 package com.github.sadikovi.spark.netflow
 
+import java.io.IOException
+
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
@@ -304,6 +306,11 @@ object DefaultSource {
         val reader = NetFlowReader.prepareReader(stream)
         val header = reader.getHeader()
         Some(header.getFlowVersion())
+      } catch {
+        case ioe: IOException =>
+          throw new IOException(
+            s"Failed to infer version for provided NetFlow files using path '$path', " +
+            s"reason: $ioe. Try specifying version manually using 'version' option", ioe)
       } finally {
         if (stream != null) {
           stream.close()

--- a/src/test/scala/com/github/sadikovi/spark/netflow/NetFlowSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/NetFlowSuite.scala
@@ -470,6 +470,27 @@ class NetFlowSuite extends SparkNetFlowTestSuite {
     new DefaultSource().equals(new DefaultSource()) should be (true)
     new DefaultSource().equals(null) should be (false)
   }
+
+  test("inferVersion - return None for empty paths") {
+    val conf = spark.sparkContext.hadoopConfiguration
+    DefaultSource.inferVersion(conf, Nil) should be (None)
+  }
+
+  test("inferVersion - return Some for correct NetFlow file") {
+    val conf = spark.sparkContext.hadoopConfiguration
+    DefaultSource.inferVersion(conf, new Path(path1) :: Nil) should be (Some(5))
+    DefaultSource.inferVersion(conf, new Path(path2) :: Nil) should be (Some(5))
+    DefaultSource.inferVersion(conf, new Path(path6) :: Nil) should be (Some(7))
+    DefaultSource.inferVersion(conf, new Path(path7) :: Nil) should be (Some(7))
+  }
+
+  test("inferVersion - fail to infer for invalid file") {
+    val conf = spark.sparkContext.hadoopConfiguration
+    val err = intercept[IOException] {
+      DefaultSource.inferVersion(conf, new Path(path3) :: Nil)
+    }
+    assert(err.getMessage.contains("Failed to infer version for provided NetFlow files"))
+  }
 }
 
 /** Suite to test `ignoreCorruptFiles` option */


### PR DESCRIPTION
This PR adds error message for situation when version inference fails, e.g. when reading from folder with corrupt NetFlow files, or non-NetFlow files. Now it will show error like this:
```
java.io.IOException: Failed to infer version for provided NetFlow files using path 
'file:/spark-netflow/temp/attribute.spark', reason: java.io.IOException: Corrupt 
NetFlow file. Wrong magic number. Try specifying version manually using 'version' option

  ... 48 elided
Caused by: java.io.IOException: Corrupt NetFlow file. Wrong magic number
  at com.github.sadikovi.netflowlib.NetFlowReader.<init>(NetFlowReader.java:137)
  at com.github.sadikovi.netflowlib.NetFlowReader.prepareReader(NetFlowReader.java:80)
```


Closes #62.