### PR TITLE
Report file for exceptions

### DIFF
--- a/src/test/scala/com/github/sadikovi/spark/netflow/NetFlowSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/NetFlowSuite.scala
@@ -162,8 +162,9 @@ class NetFlowSuite extends SparkNetFlowTestSuite {
         load(s"file:$path3").count
     }
     val msg = err.getMessage()
-    assert(msg.contains("java.io.IOException: " +
-      "Corrupt NetFlow file. Wrong magic number"))
+    assert(msg.contains("Corrupt NetFlow file. Wrong magic number"))
+    // check that message contains file path
+    assert(msg.contains(path3))
   }
 
   test("fail to read data of corrupt file") {
@@ -173,7 +174,9 @@ class NetFlowSuite extends SparkNetFlowTestSuite {
       df.select("srcip").count
     }
     val msg = err.getMessage()
-    assert(msg.contains("java.lang.IllegalArgumentException: Unexpected EOF"))
+    assert(msg.contains("Unexpected EOF"))
+    // check that message contains file path
+    assert(msg.contains(path4))
   }
 
   test("fail to read unsupported version 8") {


### PR DESCRIPTION
This PR addresses issue #67, and adds reporting of corrupt file when read fails either during reading of a header or record. Patch handles issue in `DefaultSource` directly, not in `NetFlowReader` - reason is that reader is stream based and introducing path attribute does not make sense and would involve fair amount of changes to either add it and propagate into buffers or convert reader to work on file system and path.