### PR TITLE
Return iterator of InternalRow directly from library

### DIFF
--- a/src/main/java/com/github/sadikovi/netflowlib/Strategies.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/Strategies.java
@@ -16,7 +16,6 @@
 
 package com.github.sadikovi.netflowlib;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 

--- a/src/main/java/com/github/sadikovi/netflowlib/predicate/Columns.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/predicate/Columns.java
@@ -51,6 +51,9 @@ public final class Columns {
       return columnType;
     }
 
+    /** Get number of bytes per unsigned value */
+    public abstract int getUnsignedBytes();
+
     /** Get column offset in a record */
     public int getColumnOffset() {
       return columnOffset;
@@ -103,6 +106,11 @@ public final class Columns {
     }
 
     @Override
+    public int getUnsignedBytes() {
+      return 1;
+    }
+
+    @Override
     public Object getMin() {
       return minValue;
     }
@@ -128,6 +136,11 @@ public final class Columns {
 
     public ShortColumn(String name, int offset) {
       this(name, offset, (short) 0, Short.MAX_VALUE);
+    }
+
+    @Override
+    public int getUnsignedBytes() {
+      return 1;
     }
 
     @Override
@@ -159,6 +172,11 @@ public final class Columns {
     }
 
     @Override
+    public int getUnsignedBytes() {
+      return 2;
+    }
+
+    @Override
     public Object getMin() {
       return minValue;
     }
@@ -184,6 +202,11 @@ public final class Columns {
 
     public LongColumn(String name, int offset) {
       this(name, offset, (long) 0, Long.MAX_VALUE);
+    }
+
+    @Override
+    public int getUnsignedBytes() {
+      return 4;
     }
 
     @Override

--- a/src/main/java/com/github/sadikovi/netflowlib/record/ByteBufRow.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/record/ByteBufRow.java
@@ -16,7 +16,10 @@
 
 package com.github.sadikovi.netflowlib.record;
 
-import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
@@ -28,12 +31,12 @@ import org.apache.spark.unsafe.types.UTF8String;
 public class ByteBufRow extends InternalRow {
   private final int numFields;
   private final int[] offsets;
-  private final ByteBuffer buf;
+  private final ByteBuf buf;
 
-  ByteBufRow(int[] offsets, byte[] data) {
+  ByteBufRow(int[] offsets, byte[] data, ByteOrder byteOrder) {
     this.numFields = (offsets != null && offsets.length > 0) ? offsets.length : 0;
     this.offsets = offsets;
-    this.buf = ByteBuffer.wrap(data);
+    this.buf = Unpooled.wrappedBuffer(data).order(byteOrder);
   }
 
   @Override
@@ -83,7 +86,7 @@ public class ByteBufRow extends InternalRow {
     System.arraycopy(buf.array(), buf.arrayOffset(), dataCopy, 0, dataCopy.length);
     int[] offsetsCopy = new int[offsets.length];
     System.arraycopy(offsets, 0, offsetsCopy, 0, offsets.length);
-    return new ByteBufRow(offsetsCopy, dataCopy);
+    return new ByteBufRow(offsetsCopy, dataCopy, buf.order());
   }
 
   @Override
@@ -103,27 +106,27 @@ public class ByteBufRow extends InternalRow {
 
   @Override
   public boolean getBoolean(int ordinal) {
-    return buf.get(offsets[ordinal]) != 0;
+    return buf.getBoolean(offsets[ordinal]);
   }
 
   @Override
   public byte getByte(int ordinal) {
-    return buf.get(offsets[ordinal]);
+    return buf.getByte(offsets[ordinal]);
   }
 
   @Override
   public short getShort(int ordinal) {
-    return buf.getShort(offsets[ordinal]);
+    return buf.getUnsignedByte(offsets[ordinal]);
   }
 
   @Override
   public int getInt(int ordinal) {
-    return buf.getInt(offsets[ordinal]);
+    return buf.getUnsignedShort(offsets[ordinal]);
   }
 
   @Override
   public long getLong(int ordinal) {
-    return buf.getLong(offsets[ordinal]);
+    return buf.getUnsignedInt(offsets[ordinal]);
   }
 
   @Override

--- a/src/main/java/com/github/sadikovi/netflowlib/record/ByteBufRow.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/record/ByteBufRow.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.netflowlib.record;
+
+import java.nio.ByteBuffer;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayData;
+import org.apache.spark.sql.types.*;
+import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.unsafe.types.CalendarInterval;
+import org.apache.spark.unsafe.types.UTF8String;
+
+public class ByteBufRow extends InternalRow {
+  private final int numFields;
+  private final int[] offsets;
+  private final ByteBuffer buf;
+
+  ByteBufRow(int[] offsets, byte[] data) {
+    this.numFields = (offsets != null && offsets.length > 0) ? offsets.length : 0;
+    this.offsets = offsets;
+    this.buf = ByteBuffer.wrap(data);
+  }
+
+  @Override
+  public int numFields() {
+    return this.numFields;
+  }
+
+  public void setNullAt(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void update(int ordinal, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void setBoolean(int ordinal, boolean value) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void setByte(int ordinal, byte value) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void setShort(int ordinal, short value) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void setInt(int ordinal, int value) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void setLong(int ordinal, long value) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void setFloat(int ordinal, float value) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void setDouble(int ordinal, double value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public InternalRow copy() {
+    byte[] dataCopy = new byte[buf.array().length];
+    System.arraycopy(buf.array(), buf.arrayOffset(), dataCopy, 0, dataCopy.length);
+    int[] offsetsCopy = new int[offsets.length];
+    System.arraycopy(offsets, 0, offsetsCopy, 0, offsets.length);
+    return new ByteBufRow(offsetsCopy, dataCopy);
+  }
+
+  @Override
+  public boolean anyNull() {
+    // netflow data never has nulls
+    return false;
+  }
+
+  //////////////////////////////////////////////////////////////
+  // Specialized getters
+  //////////////////////////////////////////////////////////////
+
+  @Override
+  public boolean isNullAt(int ordinal) {
+    return false;
+  }
+
+  @Override
+  public boolean getBoolean(int ordinal) {
+    return buf.get(offsets[ordinal]) != 0;
+  }
+
+  @Override
+  public byte getByte(int ordinal) {
+    return buf.get(offsets[ordinal]);
+  }
+
+  @Override
+  public short getShort(int ordinal) {
+    return buf.getShort(offsets[ordinal]);
+  }
+
+  @Override
+  public int getInt(int ordinal) {
+    return buf.getInt(offsets[ordinal]);
+  }
+
+  @Override
+  public long getLong(int ordinal) {
+    return buf.getLong(offsets[ordinal]);
+  }
+
+  @Override
+  public float getFloat(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double getDouble(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Decimal getDecimal(int ordinal, int precision, int scale) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public UTF8String getUTF8String(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte[] getBinary(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public CalendarInterval getInterval(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public InternalRow getStruct(int ordinal, int numFields) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ArrayData getArray(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public MapData getMap(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Object get(int ordinal, DataType dataType) {
+    if (isNullAt(ordinal) || dataType instanceof NullType) {
+      return null;
+    } else if (dataType instanceof BooleanType) {
+      return getBoolean(ordinal);
+    } else if (dataType instanceof ByteType) {
+      return getByte(ordinal);
+    } else if (dataType instanceof ShortType) {
+      return getShort(ordinal);
+    } else if (dataType instanceof IntegerType) {
+      return getInt(ordinal);
+    } else if (dataType instanceof LongType) {
+      return getLong(ordinal);
+    } else if (dataType instanceof FloatType) {
+      return getFloat(ordinal);
+    } else if (dataType instanceof DoubleType) {
+      return getDouble(ordinal);
+    } else if (dataType instanceof DecimalType) {
+      DecimalType dt = (DecimalType) dataType;
+      return getDecimal(ordinal, dt.precision(), dt.scale());
+    } else if (dataType instanceof DateType) {
+      return getInt(ordinal);
+    } else if (dataType instanceof TimestampType) {
+      return getLong(ordinal);
+    } else if (dataType instanceof BinaryType) {
+      return getBinary(ordinal);
+    } else if (dataType instanceof StringType) {
+      return getUTF8String(ordinal);
+    } else if (dataType instanceof CalendarIntervalType) {
+      return getInterval(ordinal);
+    } else if (dataType instanceof StructType) {
+      return getStruct(ordinal, ((StructType) dataType).size());
+    } else if (dataType instanceof ArrayType) {
+      return getArray(ordinal);
+    } else if (dataType instanceof MapType) {
+      return getMap(ordinal);
+    } else if (dataType instanceof UserDefinedType) {
+      return get(ordinal, ((UserDefinedType)dataType).sqlType());
+    } else {
+      throw new UnsupportedOperationException("Unsupported data type " + dataType.simpleString());
+    }
+  }
+}

--- a/src/main/java/com/github/sadikovi/netflowlib/record/PredicateRecordMaterializer.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/record/PredicateRecordMaterializer.java
@@ -96,12 +96,13 @@ public final class PredicateRecordMaterializer extends RecordMaterializer implem
       int i = 0, offset = 0, len = 0;
       while (i < numColumns) {
         len = columns[i].getUnsignedBytes();
-        offsets[i] = offset;
         System.arraycopy(buffer.array(), buffer.arrayOffset() + columns[i].getColumnOffset(),
           data, offset, len);
+        offsets[i] = offset;
         offset += len;
+        ++i;
       }
-      return new ByteBufRow(offsets, data);
+      return new ByteBufRow(offsets, data, buffer.order());
     }
   }
 

--- a/src/main/java/com/github/sadikovi/netflowlib/record/RecordMaterializer.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/record/RecordMaterializer.java
@@ -18,6 +18,8 @@ package com.github.sadikovi.netflowlib.record;
 
 import io.netty.buffer.ByteBuf;
 
+import org.apache.spark.sql.catalyst.InternalRow;
+
 import com.github.sadikovi.netflowlib.predicate.Columns.Column;
 import com.github.sadikovi.netflowlib.predicate.Inspectors.ValueInspector;
 import com.github.sadikovi.netflowlib.predicate.Operators.FilterPredicate;
@@ -31,6 +33,8 @@ public abstract class RecordMaterializer {
   RecordMaterializer() { }
 
   public abstract Object[] processRecord(ByteBuf buffer);
+
+  public abstract InternalRow processRow(ByteBuf buffer);
 
   /** Read buffer bytes sequence for column offset */
   public Object readField(Column column, ByteBuf buffer) {

--- a/src/main/java/com/github/sadikovi/netflowlib/record/ScanRecordMaterializer.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/record/ScanRecordMaterializer.java
@@ -60,12 +60,13 @@ public final class ScanRecordMaterializer extends RecordMaterializer {
     int i = 0, offset = 0, len = 0;
     while (i < numColumns) {
       len = columns[i].getUnsignedBytes();
-      offsets[i] = offset;
       System.arraycopy(buffer.array(), buffer.arrayOffset() + columns[i].getColumnOffset(),
         data, offset, len);
+      offsets[i] = offset;
       offset += len;
+      ++i;
     }
-    return new ByteBufRow(offsets, data);
+    return new ByteBufRow(offsets, data, buffer.order());
   }
 
   private final Column[] columns;

--- a/src/main/java/com/github/sadikovi/netflowlib/record/ScanRecordMaterializer.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/record/ScanRecordMaterializer.java
@@ -18,6 +18,8 @@ package com.github.sadikovi.netflowlib.record;
 
 import io.netty.buffer.ByteBuf;
 
+import org.apache.spark.sql.catalyst.InternalRow;
+
 import com.github.sadikovi.netflowlib.predicate.Columns.Column;
 import com.github.sadikovi.netflowlib.predicate.Columns.ByteColumn;
 import com.github.sadikovi.netflowlib.predicate.Columns.ShortColumn;
@@ -34,6 +36,10 @@ public final class ScanRecordMaterializer extends RecordMaterializer {
   public ScanRecordMaterializer(Column[] columns) {
     this.columns = columns;
     numColumns = columns.length;
+    recordSize = 0;
+    for (int i = 0; i < numColumns; i++) {
+      recordSize += this.columns[i].getUnsignedBytes();
+    }
   }
 
   @Override
@@ -47,6 +53,23 @@ public final class ScanRecordMaterializer extends RecordMaterializer {
     return newRecord;
   }
 
+  @Override
+  public InternalRow processRow(ByteBuf buffer) {
+    byte[] data = new byte[recordSize];
+    int[] offsets = new int[numColumns];
+    int i = 0, offset = 0, len = 0;
+    while (i < numColumns) {
+      len = columns[i].getUnsignedBytes();
+      offsets[i] = offset;
+      System.arraycopy(buffer.array(), buffer.arrayOffset() + columns[i].getColumnOffset(),
+        data, offset, len);
+      offset += len;
+    }
+    return new ByteBufRow(offsets, data);
+  }
+
   private final Column[] columns;
   private final int numColumns;
+  // total record size in bytes for selected columns
+  private int recordSize;
 }

--- a/src/main/scala/com/github/sadikovi/spark/netflow/sources/ResolvedInterface.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/sources/ResolvedInterface.scala
@@ -30,7 +30,7 @@ import com.github.sadikovi.netflowlib.predicate.Columns.Column
 private[spark] case class MappedColumn(
   columnName: String,
   internalColumn: Column,
-  collectStatistics: Boolean,
+  sqlType: DataType,
   convertFunction: Option[ConvertFunction]
 )
 
@@ -62,7 +62,7 @@ abstract class ResolvedInterface {
       if (applyConversion && column.convertFunction.isDefined) {
         StructField(column.columnName, StringType, false)
       } else {
-        StructField(column.columnName, javaToSQLType(column.internalColumn.getColumnType()), false)
+        StructField(column.columnName, column.sqlType, false)
       }
     })
     StructType(sqlColumns)
@@ -76,9 +76,6 @@ abstract class ResolvedInterface {
 
   /** Get first `MappedColumn` as `Option`. */
   def getFirstColumnOption(): Option[MappedColumn] = columns.headOption
-
-  /** Get columns with enabled statistics */
-  def getStatisticsColumns(): Seq[MappedColumn] = columns.filter { _.collectStatistics }
 
   /** Get `MappedColumn` for a specified column name. Fail, if column name is not present. */
   def getColumn(columnName: String): MappedColumn = {

--- a/src/main/scala/com/github/sadikovi/spark/netflow/version5/DefaultProvider.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/version5/DefaultProvider.scala
@@ -16,6 +16,8 @@
 
 package com.github.sadikovi.spark.netflow.version5
 
+import org.apache.spark.sql.types._
+
 import com.github.sadikovi.netflowlib.version.NetFlowV5
 import com.github.sadikovi.spark.netflow.sources._
 
@@ -28,30 +30,30 @@ class DefaultProvider extends NetFlowProvider {
 /** NetFlow interface for version 5. */
 private class InterfaceV5 extends ResolvedInterface {
   override protected val columns: Seq[MappedColumn] = Seq(
-    MappedColumn("unix_secs", NetFlowV5.FIELD_UNIX_SECS, true, None),
-    MappedColumn("unix_nsecs", NetFlowV5.FIELD_UNIX_NSECS, false, None),
-    MappedColumn("sysuptime", NetFlowV5.FIELD_SYSUPTIME, false, None),
-    MappedColumn("exaddr", NetFlowV5.FIELD_EXADDR, false, Some(IPv4ConvertFunction())),
-    MappedColumn("srcip", NetFlowV5.FIELD_SRCADDR, true, Some(IPv4ConvertFunction())),
-    MappedColumn("dstip", NetFlowV5.FIELD_DSTADDR, true, Some(IPv4ConvertFunction())),
-    MappedColumn("nexthop", NetFlowV5.FIELD_NEXTHOP, false, Some(IPv4ConvertFunction())),
-    MappedColumn("input", NetFlowV5.FIELD_INPUT, false, None),
-    MappedColumn("output", NetFlowV5.FIELD_OUTPUT, false, None),
-    MappedColumn("packets", NetFlowV5.FIELD_DPKTS, false, None),
-    MappedColumn("octets", NetFlowV5.FIELD_DOCTETS, false, None),
-    MappedColumn("first_flow", NetFlowV5.FIELD_FIRST, false, None),
-    MappedColumn("last_flow", NetFlowV5.FIELD_LAST, false, None),
-    MappedColumn("srcport", NetFlowV5.FIELD_SRCPORT, true, None),
-    MappedColumn("dstport", NetFlowV5.FIELD_DSTPORT, true, None),
-    MappedColumn("protocol", NetFlowV5.FIELD_PROT, true, Some(ProtocolConvertFunction())),
-    MappedColumn("tos", NetFlowV5.FIELD_TOS, false, None),
-    MappedColumn("tcp_flags", NetFlowV5.FIELD_TCP_FLAGS, false, None),
-    MappedColumn("engine_type", NetFlowV5.FIELD_ENGINE_TYPE, false, None),
-    MappedColumn("engine_id", NetFlowV5.FIELD_ENGINE_ID, false, None),
-    MappedColumn("src_mask", NetFlowV5.FIELD_SRC_MASK, false, None),
-    MappedColumn("dst_mask", NetFlowV5.FIELD_DST_MASK, false, None),
-    MappedColumn("src_as", NetFlowV5.FIELD_SRC_AS, false, None),
-    MappedColumn("dst_as", NetFlowV5.FIELD_DST_AS, false, None)
+    MappedColumn("unix_secs", NetFlowV5.FIELD_UNIX_SECS, LongType, None),
+    MappedColumn("unix_nsecs", NetFlowV5.FIELD_UNIX_NSECS, LongType, None),
+    MappedColumn("sysuptime", NetFlowV5.FIELD_SYSUPTIME, LongType, None),
+    MappedColumn("exaddr", NetFlowV5.FIELD_EXADDR, LongType, Some(IPv4ConvertFunction())),
+    MappedColumn("srcip", NetFlowV5.FIELD_SRCADDR, LongType, Some(IPv4ConvertFunction())),
+    MappedColumn("dstip", NetFlowV5.FIELD_DSTADDR, LongType, Some(IPv4ConvertFunction())),
+    MappedColumn("nexthop", NetFlowV5.FIELD_NEXTHOP, LongType, Some(IPv4ConvertFunction())),
+    MappedColumn("input", NetFlowV5.FIELD_INPUT, IntegerType, None),
+    MappedColumn("output", NetFlowV5.FIELD_OUTPUT, IntegerType, None),
+    MappedColumn("packets", NetFlowV5.FIELD_DPKTS, LongType, None),
+    MappedColumn("octets", NetFlowV5.FIELD_DOCTETS, LongType, None),
+    MappedColumn("first_flow", NetFlowV5.FIELD_FIRST, LongType, None),
+    MappedColumn("last_flow", NetFlowV5.FIELD_LAST, LongType, None),
+    MappedColumn("srcport", NetFlowV5.FIELD_SRCPORT, IntegerType, None),
+    MappedColumn("dstport", NetFlowV5.FIELD_DSTPORT, IntegerType, None),
+    MappedColumn("protocol", NetFlowV5.FIELD_PROT, ShortType, Some(ProtocolConvertFunction())),
+    MappedColumn("tos", NetFlowV5.FIELD_TOS, ShortType, None),
+    MappedColumn("tcp_flags", NetFlowV5.FIELD_TCP_FLAGS, ShortType, None),
+    MappedColumn("engine_type", NetFlowV5.FIELD_ENGINE_TYPE, ShortType, None),
+    MappedColumn("engine_id", NetFlowV5.FIELD_ENGINE_ID, ShortType, None),
+    MappedColumn("src_mask", NetFlowV5.FIELD_SRC_MASK, ShortType, None),
+    MappedColumn("dst_mask", NetFlowV5.FIELD_DST_MASK, ShortType, None),
+    MappedColumn("src_as", NetFlowV5.FIELD_SRC_AS, IntegerType, None),
+    MappedColumn("dst_as", NetFlowV5.FIELD_DST_AS, IntegerType, None)
   )
 
   override def version(): Short = 5

--- a/src/main/scala/com/github/sadikovi/spark/netflow/version7/DefaultProvider.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/version7/DefaultProvider.scala
@@ -16,6 +16,8 @@
 
 package com.github.sadikovi.spark.netflow.version7
 
+import org.apache.spark.sql.types._
+
 import com.github.sadikovi.netflowlib.version.NetFlowV7
 import com.github.sadikovi.spark.netflow.sources._
 
@@ -28,32 +30,32 @@ class DefaultProvider extends NetFlowProvider {
 /** NetFlow interface for version 7. */
 private class InterfaceV7 extends ResolvedInterface {
   override protected val columns: Seq[MappedColumn] = Seq(
-    MappedColumn("unix_secs", NetFlowV7.FIELD_UNIX_SECS, true, None),
-    MappedColumn("unix_nsecs", NetFlowV7.FIELD_UNIX_NSECS, false, None),
-    MappedColumn("sysuptime", NetFlowV7.FIELD_SYSUPTIME, false, None),
-    MappedColumn("exaddr", NetFlowV7.FIELD_EXADDR, false, Some(IPv4ConvertFunction())),
-    MappedColumn("srcip", NetFlowV7.FIELD_SRCADDR, true, Some(IPv4ConvertFunction())),
-    MappedColumn("dstip", NetFlowV7.FIELD_DSTADDR, true, Some(IPv4ConvertFunction())),
-    MappedColumn("nexthop", NetFlowV7.FIELD_NEXTHOP, false, Some(IPv4ConvertFunction())),
-    MappedColumn("input", NetFlowV7.FIELD_INPUT, false, None),
-    MappedColumn("output", NetFlowV7.FIELD_OUTPUT, false, None),
-    MappedColumn("packets", NetFlowV7.FIELD_DPKTS, false, None),
-    MappedColumn("octets", NetFlowV7.FIELD_DOCTETS, false, None),
-    MappedColumn("first_flow", NetFlowV7.FIELD_FIRST, false, None),
-    MappedColumn("last_flow", NetFlowV7.FIELD_LAST, false, None),
-    MappedColumn("srcport", NetFlowV7.FIELD_SRCPORT, true, None),
-    MappedColumn("dstport", NetFlowV7.FIELD_DSTPORT, true, None),
-    MappedColumn("protocol", NetFlowV7.FIELD_PROT, true, Some(ProtocolConvertFunction())),
-    MappedColumn("tos", NetFlowV7.FIELD_TOS, false, None),
-    MappedColumn("tcp_flags", NetFlowV7.FIELD_TCP_FLAGS, false, None),
-    MappedColumn("flags", NetFlowV7.FIELD_FLAGS, false, None),
-    MappedColumn("engine_type", NetFlowV7.FIELD_ENGINE_TYPE, false, None),
-    MappedColumn("engine_id", NetFlowV7.FIELD_ENGINE_ID, false, None),
-    MappedColumn("src_mask", NetFlowV7.FIELD_SRC_MASK, false, None),
-    MappedColumn("dst_mask", NetFlowV7.FIELD_DST_MASK, false, None),
-    MappedColumn("src_as", NetFlowV7.FIELD_SRC_AS, false, None),
-    MappedColumn("dst_as", NetFlowV7.FIELD_DST_AS, false, None),
-    MappedColumn("router_sc", NetFlowV7.FIELD_ROUTER_SC, false, Some(IPv4ConvertFunction()))
+    MappedColumn("unix_secs", NetFlowV7.FIELD_UNIX_SECS, LongType, None),
+    MappedColumn("unix_nsecs", NetFlowV7.FIELD_UNIX_NSECS, LongType, None),
+    MappedColumn("sysuptime", NetFlowV7.FIELD_SYSUPTIME, LongType, None),
+    MappedColumn("exaddr", NetFlowV7.FIELD_EXADDR, LongType, Some(IPv4ConvertFunction())),
+    MappedColumn("srcip", NetFlowV7.FIELD_SRCADDR, LongType, Some(IPv4ConvertFunction())),
+    MappedColumn("dstip", NetFlowV7.FIELD_DSTADDR, LongType, Some(IPv4ConvertFunction())),
+    MappedColumn("nexthop", NetFlowV7.FIELD_NEXTHOP, LongType, Some(IPv4ConvertFunction())),
+    MappedColumn("input", NetFlowV7.FIELD_INPUT, IntegerType, None),
+    MappedColumn("output", NetFlowV7.FIELD_OUTPUT, IntegerType, None),
+    MappedColumn("packets", NetFlowV7.FIELD_DPKTS, LongType, None),
+    MappedColumn("octets", NetFlowV7.FIELD_DOCTETS, LongType, None),
+    MappedColumn("first_flow", NetFlowV7.FIELD_FIRST, LongType, None),
+    MappedColumn("last_flow", NetFlowV7.FIELD_LAST, LongType, None),
+    MappedColumn("srcport", NetFlowV7.FIELD_SRCPORT, IntegerType, None),
+    MappedColumn("dstport", NetFlowV7.FIELD_DSTPORT, IntegerType, None),
+    MappedColumn("protocol", NetFlowV7.FIELD_PROT, ShortType, Some(ProtocolConvertFunction())),
+    MappedColumn("tos", NetFlowV7.FIELD_TOS, ShortType, None),
+    MappedColumn("tcp_flags", NetFlowV7.FIELD_TCP_FLAGS, ShortType, None),
+    MappedColumn("flags", NetFlowV7.FIELD_FLAGS, ShortType, None),
+    MappedColumn("engine_type", NetFlowV7.FIELD_ENGINE_TYPE, ShortType, None),
+    MappedColumn("engine_id", NetFlowV7.FIELD_ENGINE_ID, ShortType, None),
+    MappedColumn("src_mask", NetFlowV7.FIELD_SRC_MASK, ShortType, None),
+    MappedColumn("dst_mask", NetFlowV7.FIELD_DST_MASK, ShortType, None),
+    MappedColumn("src_as", NetFlowV7.FIELD_SRC_AS, IntegerType, None),
+    MappedColumn("dst_as", NetFlowV7.FIELD_DST_AS, IntegerType, None),
+    MappedColumn("router_sc", NetFlowV7.FIELD_ROUTER_SC, LongType, Some(IPv4ConvertFunction()))
   )
 
   override def version(): Short = 7

--- a/src/test/scala/com/github/sadikovi/spark/netflow/sources/testproviders.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/sources/testproviders.scala
@@ -16,6 +16,8 @@
 
 package com.github.sadikovi.spark.netflow.sources
 
+import org.apache.spark.sql.types._
+
 import com.github.sadikovi.netflowlib.predicate.Columns.{ByteColumn, ShortColumn, IntColumn, LongColumn}
 
 /** Test providers */
@@ -50,23 +52,23 @@ private class TestEmptyInterface extends ResolvedInterface {
 
 private class TestFullInterface extends ResolvedInterface {
   override protected val columns: Seq[MappedColumn] = Seq(
-    MappedColumn("test", new LongColumn("test", 0), false, None))
+    MappedColumn("test", new LongColumn("test", 0), LongType, None))
 
   override def version(): Short = -2
 }
 
 private class Test1FullInterface extends ResolvedInterface {
   override protected val columns: Seq[MappedColumn] = Seq(
-    MappedColumn("duplicate", new LongColumn("duplicate", 0), false, None),
-    MappedColumn("duplicate", new LongColumn("duplicate", 0), false, None))
+    MappedColumn("duplicate", new LongColumn("duplicate", 0), LongType, None),
+    MappedColumn("duplicate", new LongColumn("duplicate", 0), LongType, None))
 
   override def version(): Short = -3
 }
 
 private class Test2FullInterface extends ResolvedInterface {
   override protected val columns: Seq[MappedColumn] = Seq(
-    MappedColumn("test", new LongColumn("test1", 0), false, None),
-    MappedColumn("test", new LongColumn("test2", 1), false, None))
+    MappedColumn("test", new LongColumn("test1", 0), LongType, None),
+    MappedColumn("test", new LongColumn("test2", 1), LongType, None))
 
   override def version(): Short = -3
 }
@@ -81,10 +83,10 @@ private class FakeDefaultProvider extends NetFlowProvider {
 
 private class FakeInterface extends ResolvedInterface {
   override protected val columns: Seq[MappedColumn] = Seq(
-    MappedColumn("col1", new ByteColumn("col1", 0), false, None),
-    MappedColumn("col2", new ShortColumn("col2", 0), false, None),
-    MappedColumn("col3", new IntColumn("col3", 0), false, None),
-    MappedColumn("col4", new LongColumn("col4", 0), false, None))
+    MappedColumn("col1", new ByteColumn("col1", 0), ByteType, None),
+    MappedColumn("col2", new ShortColumn("col2", 0), ShortType, None),
+    MappedColumn("col3", new IntColumn("col3", 0), IntegerType, None),
+    MappedColumn("col4", new LongColumn("col4", 0), LongType, None))
 
   override def version(): Short = -1
 }


### PR DESCRIPTION
This PR adds row iterator to the netflow reader to return `Iterator<InternalRow>` and make it compatible with Spark SQL. Conversion is implemented as copy into new internal row with updated fields. Benchmarks show that this change is slower than current master, but changes exposed couple of improvements that can be made.

Master (2.0.2):
```
Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
NetFlow full scan:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------
Scan, stringify = F                      9664 / 9810        103.5      966383.4       1.0X
Scan, stringify = T                    20641 / 20772         48.4     2064072.8       0.5X

Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
NetFlow predicate scan:             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------
Predicate pushdown = F, high           23778 / 24084         42.1     2377846.1       1.0X
Predicate pushdown = T, high           23411 / 23569         42.7     2341062.5       1.0X
Predicate pushdown = F, low            13737 / 13833         72.8     1373701.3       1.7X
Predicate pushdown = T, low              3169 / 3210        315.6      316861.1       7.5X
```

This patch:
```
Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
NetFlow full scan:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------
Scan, stringify = F                    12426 / 12475         80.5     1242558.0       1.0X
Scan, stringify = T                    35894 / 36084         27.9     3589417.5       0.3X

Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
NetFlow predicate scan:             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------
Predicate pushdown = F, high           40144 / 40220         24.9     4014354.2       1.0X
Predicate pushdown = T, high           40680 / 41479         24.6     4068008.7       1.0X
Predicate pushdown = F, low            28519 / 28655         35.1     2851922.8       1.4X
Predicate pushdown = T, low              3211 / 3302        311.4      321085.1      12.5X
```