### PR TITLE
Remove netty ByteBuf dependency, refactor IO

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,37 +117,28 @@ Latest benchmarks:
 - Iterations: 5
 - Files: file:/Users/sadikovi/developer/spark-netflow/temp/ftn/0[1,2,3]/ft*
 - Version: 5
-Running benchmark: NetFlow full scan
-  Running case: Scan, stringify = F
-  Running case: Scan, stringify = T                                             
 
+Java HotSpot(TM) 64-Bit Server VM 1.7.0_80-b15 on Mac OS X 10.12.4
 Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
-NetFlow full scan:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------
-Scan, stringify = F                       364 /  462       2748.0       36389.9       1.0X
-Scan, stringify = T                       923 /  935       1082.9       92347.8       0.4X
+NetFlow full scan:                       Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+Scan, stringify = F                            567 /  633          0.0       56726.7       1.0X
+Scan, stringify = T                            968 / 1049          0.0       96824.6       0.6X
 
-Running benchmark: NetFlow predicate scan
-  Running case: Predicate pushdown = F, high
-  Running case: Predicate pushdown = T, high                                    
-  Running case: Predicate pushdown = F, low                                     
-  Running case: Predicate pushdown = T, low                                     
-
+Java HotSpot(TM) 64-Bit Server VM 1.7.0_80-b15 on Mac OS X 10.12.4
 Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
-NetFlow predicate scan:             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------
-Predicate pushdown = F, high             1009 / 1094        991.2      100892.6       1.0X
-Predicate pushdown = T, high             1056 / 2029        947.2      105570.7       1.0X
-Predicate pushdown = F, low               766 /  833       1304.9       76633.3       1.3X
-Predicate pushdown = T, low               175 /  181       5709.3       17515.4       5.8X
+NetFlow predicate scan:                  Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+Predicate pushdown = F, high                  1148 / 1200          0.0      114845.4       1.0X
+Predicate pushdown = T, high                  1208 / 1257          0.0      120818.0       1.0X
+Predicate pushdown = F, low                    706 /  732          0.0       70559.3       1.6X
+Predicate pushdown = T, low                    226 /  243          0.0       22575.0       5.1X
 
-Running benchmark: NetFlow aggregated report
-  Running case: Aggregated report
-
+Java HotSpot(TM) 64-Bit Server VM 1.7.0_80-b15 on Mac OS X 10.12.4
 Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
-NetFlow aggregated report:          Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------
-Aggregated report                        1362 / 2242        734.3      136183.3       1.0X
+NetFlow aggregated report:               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------
+Aggregated report                             2171 / 2270          0.0      217089.9       1.0X
 ```
 
 ## Using `netflowlib` library separately
@@ -165,10 +156,6 @@ creates statistics on time, so time filter can be resolved upfront
 to file header and iterator of rows, allows to pass additional predicate and statistics
 - `com.github.sadikovi.netflowlib.NetFlowHeader` header information can be accessed using this
 class from `NetFlowReader.getHeader()`, see class for more information on flags available
-
-Note that library has only one external dependency on `io.netty.buffer.ByteBuf` buffers, which
-could be replaced with standard Java buffer functionality, but since it was built for being used as
-part of a spark-package, this dependency comes with Spark.
 
 Here is the general usage pattern:
 ```scala

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,8 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client")
 )
 
-// check deprecation without manual restart
+// check deprecation and unchecked without manual restart
+javacOptions in ThisBuild ++= Seq("-Xlint:unchecked")
 scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation", "-feature")
 
 // Display full-length stacktraces from ScalaTest:

--- a/src/main/java/com/github/sadikovi/netflowlib/Strategies.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/Strategies.java
@@ -16,7 +16,6 @@
 
 package com.github.sadikovi.netflowlib;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 

--- a/src/main/java/com/github/sadikovi/netflowlib/predicate/Columns.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/predicate/Columns.java
@@ -18,7 +18,9 @@ package com.github.sadikovi.netflowlib.predicate;
 
 import java.io.Serializable;
 
+import com.github.sadikovi.netflowlib.predicate.Inspectors.ValueInspector;
 import com.github.sadikovi.netflowlib.statistics.Statistics;
+import com.github.sadikovi.netflowlib.util.WrappedByteBuf;
 
 /**
  * [[Column]] is a base class for all typed columns for all NetFlow versions. They contain basic
@@ -55,6 +57,12 @@ public final class Columns {
     public int getColumnOffset() {
       return columnOffset;
     }
+
+    /** Read field from byte buffer and return value that confirms to column class */
+    public abstract Object readField(WrappedByteBuf buffer);
+
+    /** Update value inspector with value from buffer */
+    public abstract void updateValueInspector(WrappedByteBuf buffer, ValueInspector vi);
 
     @Override
     public String toString() {
@@ -103,6 +111,16 @@ public final class Columns {
     }
 
     @Override
+    public Object readField(WrappedByteBuf buffer) {
+      return buffer.getByte(getColumnOffset());
+    }
+
+    @Override
+    public void updateValueInspector(WrappedByteBuf buffer, ValueInspector vi) {
+      vi.update(buffer.getByte(getColumnOffset()));
+    }
+
+    @Override
     public Object getMin() {
       return minValue;
     }
@@ -128,6 +146,16 @@ public final class Columns {
 
     public ShortColumn(String name, int offset) {
       this(name, offset, (short) 0, Short.MAX_VALUE);
+    }
+
+    @Override
+    public Object readField(WrappedByteBuf buffer) {
+      return buffer.getUnsignedByte(getColumnOffset());
+    }
+
+    @Override
+    public void updateValueInspector(WrappedByteBuf buffer, ValueInspector vi) {
+      vi.update(buffer.getUnsignedByte(getColumnOffset()));
     }
 
     @Override
@@ -159,6 +187,16 @@ public final class Columns {
     }
 
     @Override
+    public Object readField(WrappedByteBuf buffer) {
+      return buffer.getUnsignedShort(getColumnOffset());
+    }
+
+    @Override
+    public void updateValueInspector(WrappedByteBuf buffer, ValueInspector vi) {
+      vi.update(buffer.getUnsignedShort(getColumnOffset()));
+    }
+
+    @Override
     public Object getMin() {
       return minValue;
     }
@@ -184,6 +222,16 @@ public final class Columns {
 
     public LongColumn(String name, int offset) {
       this(name, offset, (long) 0, Long.MAX_VALUE);
+    }
+
+    @Override
+    public Object readField(WrappedByteBuf buffer) {
+      return buffer.getUnsignedInt(getColumnOffset());
+    }
+
+    @Override
+    public void updateValueInspector(WrappedByteBuf buffer, ValueInspector vi) {
+      vi.update(buffer.getUnsignedInt(getColumnOffset()));
     }
 
     @Override

--- a/src/main/java/com/github/sadikovi/netflowlib/record/RecordMaterializer.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/record/RecordMaterializer.java
@@ -16,50 +16,23 @@
 
 package com.github.sadikovi.netflowlib.record;
 
-import io.netty.buffer.ByteBuf;
-
-import com.github.sadikovi.netflowlib.predicate.Columns.Column;
-import com.github.sadikovi.netflowlib.predicate.Inspectors.ValueInspector;
-import com.github.sadikovi.netflowlib.predicate.Operators.FilterPredicate;
+import com.github.sadikovi.netflowlib.util.WrappedByteBuf;
 
 /**
  * [[RecordMaterializer]] interface provides all necessary methods to parse single record and return
  * either array of values that match list and order of pruned columns, or null, if record does not
  * pass predicate. Predicate check is optional and should depend on implementation.
  */
-public abstract class RecordMaterializer {
-  RecordMaterializer() { }
+public interface RecordMaterializer {
 
-  public abstract Object[] processRecord(ByteBuf buffer);
-
-  /** Read buffer bytes sequence for column offset */
-  public Object readField(Column column, ByteBuf buffer) {
-    Class<?> type = column.getColumnType();
-    if (type.equals(Byte.class)) {
-      return buffer.getByte(column.getColumnOffset());
-    } else if (type.equals(Short.class)) {
-      return buffer.getUnsignedByte(column.getColumnOffset());
-    } else if (type.equals(Integer.class)) {
-      return buffer.getUnsignedShort(column.getColumnOffset());
-    } else if (type.equals(Long.class)) {
-      return buffer.getUnsignedInt(column.getColumnOffset());
-    } else {
-      throw new UnsupportedOperationException("Unsupported read type " + type);
-    }
-  }
-
-  public void updateValueInspector(Column column, ByteBuf buffer, ValueInspector vi) {
-    Class<?> type = column.getColumnType();
-    if (type.equals(Byte.class)) {
-      vi.update(buffer.getByte(column.getColumnOffset()));
-    } else if (type.equals(Short.class)) {
-      vi.update(buffer.getUnsignedByte(column.getColumnOffset()));
-    } else if (type.equals(Integer.class)) {
-      vi.update(buffer.getUnsignedShort(column.getColumnOffset()));
-    } else if (type.equals(Long.class)) {
-      vi.update(buffer.getUnsignedInt(column.getColumnOffset()));
-    } else {
-      throw new UnsupportedOperationException("Unsupported read type " + type);
-    }
-  }
+  /**
+   * Process record using wrapped byte buffer, array holds value for each column in projection.
+   * Returned values should have the same type as corresponding columns.
+   *
+   * Can return null array.
+   *
+   * @param buffer wrapped byte buffer
+   * @return list of values
+   */
+  Object[] processRecord(WrappedByteBuf buffer);
 }

--- a/src/main/java/com/github/sadikovi/netflowlib/record/ScanRecordMaterializer.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/record/ScanRecordMaterializer.java
@@ -16,34 +16,26 @@
 
 package com.github.sadikovi.netflowlib.record;
 
-import io.netty.buffer.ByteBuf;
-
 import com.github.sadikovi.netflowlib.predicate.Columns.Column;
-import com.github.sadikovi.netflowlib.predicate.Columns.ByteColumn;
-import com.github.sadikovi.netflowlib.predicate.Columns.ShortColumn;
-import com.github.sadikovi.netflowlib.predicate.Columns.IntColumn;
-import com.github.sadikovi.netflowlib.predicate.Columns.LongColumn;
-import com.github.sadikovi.netflowlib.predicate.Operators.FilterPredicate;
+import com.github.sadikovi.netflowlib.util.WrappedByteBuf;
 
 /**
  * [[ScanRecordMaterializer]] is part of [[FullScan]] strategy where we only scan pruned columns.
  * Note that columns might not be unique, e.g. [IntColumn("a"), ShortColumn("b"), IntColumn("a"),
  * LongColumn("c")].
  */
-public final class ScanRecordMaterializer extends RecordMaterializer {
+public final class ScanRecordMaterializer implements RecordMaterializer {
   public ScanRecordMaterializer(Column[] columns) {
     this.columns = columns;
     numColumns = columns.length;
   }
 
   @Override
-  public Object[] processRecord(ByteBuf buffer) {
+  public Object[] processRecord(WrappedByteBuf buffer) {
     Object[] newRecord = new Object[numColumns];
-
-    for (int i=0; i<numColumns; i++) {
-      newRecord[i] = readField(columns[i], buffer);
+    for (int i = 0; i < numColumns; i++) {
+      newRecord[i] = columns[i].readField(buffer);
     }
-
     return newRecord;
   }
 

--- a/src/main/java/com/github/sadikovi/netflowlib/util/WrappedByteBuf.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/util/WrappedByteBuf.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 sadikovi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.sadikovi.netflowlib.util;
+
+/**
+ * Simple alternative to java.nio.ByteBuffer with methods to read unsigned values similar to
+ * netty ByteBuf.
+ */
+public class WrappedByteBuf {
+  // only keep reference to the data
+  public WrappedByteBuf(byte[] data) {
+    this.data = data;
+  }
+
+  /**
+   * Gets a byte at the specified absolute index in this buffer.
+   * @param ordinal start position in buffer
+   * @return byte value
+   */
+  public byte getByte(int ordinal) {
+    return data[ordinal];
+  }
+
+  /**
+   * Gets an unsigned byte at the specified absolute index in this buffer.
+   * @param ordinal start position in buffer
+   * @return short value that represents unsigned byte
+   */
+  public short getUnsignedByte(int ordinal) {
+    return (short) (data[ordinal] & 0xff);
+  }
+
+  /**
+   * Get short at the specified absolute index in this buffer.
+   * @param ordinal start position in buffer
+   * @return short value
+   */
+  public short getShort(int ordinal) {
+    return (short) (data[ordinal] << 8 | data[ordinal + 1] & 0xff);
+  }
+
+  /**
+   * Gets an unsigned 16-bit short integer at the specified absolute index in this buffer.
+   * @param ordinal start position in buffer
+   * @return int value that represents unsigned short
+   */
+  public int getUnsignedShort(int ordinal) {
+    return ((data[ordinal] & 0xff) << 8) | (data[ordinal + 1] & 0xff);
+  }
+
+  /**
+   * Get int at the specified absolute index in this buffer.
+   * @param ordinal start position in buffer
+   * @return int value
+   */
+  public int getInt(int ordinal) {
+    return ((data[ordinal] & 0xff) << 24) |
+      ((data[ordinal + 1] & 0xff) << 16) |
+      ((data[ordinal + 2] & 0xff) << 8) |
+      (data[ordinal + 3] & 0xff);
+  }
+
+  /**
+   * Gets an unsigned 32-bit integer at the specified absolute index in this buffer.
+   * @param ordinal start position in buffer
+   * @return long value that represents unsigned int
+   */
+  public long getUnsignedInt(int ordinal) {
+    return getInt(ordinal) & 0xffffffffL;
+  }
+
+  /**
+   * Return reference to the underlying array.
+   * @return backed byte array
+   */
+  public byte[] array() {
+    return data;
+  }
+
+  private final byte[] data;
+}

--- a/src/main/java/com/github/sadikovi/netflowlib/util/WrappedByteBuf.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/util/WrappedByteBuf.java
@@ -83,6 +83,16 @@ public abstract class WrappedByteBuf {
   public abstract long getUnsignedInt(int ordinal);
 
   /**
+   * Transfers this buffer's data to the specified destination starting at the specified
+   * absolute index.
+   * @param index start ordinal of this buffer
+   * @param dst destination byte array
+   * @param dstIndex start index of dst array
+   * @param length number of bytes to transfer
+   */
+  public abstract void getBytes(int index, byte[] dst, int dstIndex, int length);
+
+  /**
    * Return reference to the underlying array.
    * @return backed byte array
    */
@@ -128,6 +138,11 @@ public abstract class WrappedByteBuf {
     public long getUnsignedInt(int ordinal) {
       return getInt(ordinal) & 0xffffffffL;
     }
+
+    @Override
+    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+      System.arraycopy(data, index, dst, dstIndex, length);
+    }
   }
 
   /** Wrapped byte buffer for big endianness */
@@ -167,6 +182,11 @@ public abstract class WrappedByteBuf {
     @Override
     public long getUnsignedInt(int ordinal) {
       return getInt(ordinal) & 0xffffffffL;
+    }
+
+    @Override
+    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+      System.arraycopy(data, index, dst, dstIndex, length);
     }
   }
 }

--- a/src/main/scala/com/github/sadikovi/spark/benchmark/Benchmark.scala
+++ b/src/main/scala/com/github/sadikovi/spark/benchmark/Benchmark.scala
@@ -16,11 +16,14 @@
 
 package com.github.sadikovi.spark.benchmark
 
+import java.io.{OutputStream, PrintStream}
+
 import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
 import scala.sys.process.Process
 import scala.util.Try
 
+import org.apache.commons.io.output.TeeOutputStream
 import org.apache.commons.lang3.SystemUtils
 
 /**
@@ -33,20 +36,49 @@ import org.apache.commons.lang3.SystemUtils
  *   benchmark.addCase("V2")(<function>)
  *   benchmark.run
  * This will output the average time to run each function and the rate of each function.
- *
- * The benchmark function takes one argument that is the iteration that's being run.
- *
- * If outputPerIteration is true, the timing for each run will be printed to stdout.
  */
-private[spark] class Benchmark(
+private[sadikovi] class Benchmark(
     name: String,
     valuesPerIteration: Long,
-    iters: Int = 5,
-    outputPerIteration: Boolean = false) {
+    minNumIters: Int = 5,
+    warmupTime: FiniteDuration = 2.seconds,
+    minTime: FiniteDuration = 2.seconds,
+    outputPerIteration: Boolean = false,
+    output: Option[OutputStream] = None) {
+  import Benchmark._
   val benchmarks = mutable.ArrayBuffer.empty[Benchmark.Case]
 
-  def addCase(name: String)(f: Int => Unit): Unit = {
-    benchmarks += Benchmark.Case(name, f)
+  val out = if (output.isDefined) {
+    new PrintStream(new TeeOutputStream(System.out, output.get))
+  } else {
+    System.out
+  }
+
+  /**
+   * Adds a case to run when run() is called. The given function will be run for several
+   * iterations to collect timing statistics.
+   *
+   * @param name of the benchmark case
+   * @param numIters if non-zero, forces exactly this many iterations to be run
+   */
+  def addCase(name: String, numIters: Int = 0)(f: Int => Unit): Unit = {
+    addTimerCase(name, numIters) { timer =>
+      timer.startTiming()
+      f(timer.iteration)
+      timer.stopTiming()
+    }
+  }
+
+  /**
+   * Adds a case with manual timing control. When the function is run, timing does not start
+   * until timer.startTiming() is called within the given function. The corresponding
+   * timer.stopTiming() method must be called before the function returns.
+   *
+   * @param name of the benchmark case
+   * @param numIters if non-zero, forces exactly this many iterations to be run
+   */
+  def addTimerCase(name: String, numIters: Int = 0)(f: Benchmark.Timer => Unit): Unit = {
+    benchmarks += Benchmark.Case(name, f, numIters)
   }
 
   /**
@@ -61,32 +93,94 @@ private[spark] class Benchmark(
 
     val results = benchmarks.map { c =>
       println("  Running case: " + c.name)
-      Benchmark.measure(valuesPerIteration, iters, outputPerIteration)(c.fn)
+      measure(valuesPerIteration, c.numIters)(c.fn)
     }
     println
 
     val firstBest = results.head.bestMs
     // The results are going to be processor specific so it is useful to include that.
-    println(Benchmark.getProcessorName())
-    printf("%-35s %16s %12s %13s %10s\n", name + ":", "Best/Avg Time(ms)", "Rate(M/s)",
+    out.println(Benchmark.getJVMOSInfo())
+    out.println(Benchmark.getProcessorName())
+    out.printf("%-40s %16s %12s %13s %10s\n", name + ":", "Best/Avg Time(ms)", "Rate(M/s)",
       "Per Row(ns)", "Relative")
-    println("-----------------------------------------------------------------------------------" +
-      "--------")
+    out.println("-" * 96)
     results.zip(benchmarks).foreach { case (result, benchmark) =>
-      printf("%-35s %16s %12s %13s %10s\n",
+      out.printf("%-40s %16s %12s %13s %10s\n",
         benchmark.name,
         "%5.0f / %4.0f" format (result.bestMs, result.avgMs),
-        "%10.1f" format result.bestRate * 100000,
+        "%10.1f" format result.bestRate,
         "%6.1f" format (1000 / result.bestRate),
         "%3.1fX" format (firstBest / result.bestMs))
     }
-    println
+    out.println
     // scalastyle:on
+  }
+
+  /**
+   * Runs a single function `f` for iters, returning the average time the function took and
+   * the rate of the function.
+   */
+  def measure(num: Long, overrideNumIters: Int)(f: Timer => Unit): Result = {
+    System.gc()  // ensures garbage from previous cases don't impact this one
+    val warmupDeadline = warmupTime.fromNow
+    while (!warmupDeadline.isOverdue) {
+      f(new Benchmark.Timer(-1))
+    }
+    val minIters = if (overrideNumIters != 0) overrideNumIters else minNumIters
+    val minDuration = if (overrideNumIters != 0) 0 else minTime.toNanos
+    val runTimes = mutable.ArrayBuffer[Long]()
+    var i = 0
+    while (i < minIters || runTimes.sum < minDuration) {
+      val timer = new Benchmark.Timer(i)
+      f(timer)
+      val runTime = timer.totalTime()
+      runTimes += runTime
+
+      if (outputPerIteration) {
+        // scalastyle:off
+        println(s"Iteration $i took ${runTime / 1000} microseconds")
+        // scalastyle:on
+      }
+      i += 1
+    }
+    // scalastyle:off
+    println(s"  Stopped after $i iterations, ${runTimes.sum / 1000000} ms")
+    // scalastyle:on
+    val best = runTimes.min
+    val avg = runTimes.sum / runTimes.size
+    Result(avg / 1000000.0, num / (best / 1000.0), best / 1000000.0)
   }
 }
 
-private[spark] object Benchmark {
-  case class Case(name: String, fn: Int => Unit)
+private[sadikovi] object Benchmark {
+
+  /**
+   * Object available to benchmark code to control timing e.g. to exclude set-up time.
+   *
+   * @param iteration specifies this is the nth iteration of running the benchmark case
+   */
+  class Timer(val iteration: Int) {
+    private var accumulatedTime: Long = 0L
+    private var timeStart: Long = 0L
+
+    def startTiming(): Unit = {
+      assert(timeStart == 0L, "Already started timing.")
+      timeStart = System.nanoTime
+    }
+
+    def stopTiming(): Unit = {
+      assert(timeStart != 0L, "Have not started timing.")
+      accumulatedTime += System.nanoTime - timeStart
+      timeStart = 0L
+    }
+
+    def totalTime(): Long = {
+      assert(timeStart == 0L, "Have not stopped timing.")
+      accumulatedTime
+    }
+  }
+
+  case class Case(name: String, fn: Timer => Unit, numIters: Int)
   case class Result(avgMs: Double, bestRate: Double, bestMs: Double)
 
   /** Execute command as sequence, block until get result and return output */
@@ -99,43 +193,30 @@ private[spark] object Benchmark {
    * This should return something like "Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz"
    */
   def getProcessorName(): String = {
-    if (SystemUtils.IS_OS_MAC_OSX) {
+    val cpu = if (SystemUtils.IS_OS_MAC_OSX) {
       executeAndGetOutput(Seq("/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string"))
     } else if (SystemUtils.IS_OS_LINUX) {
       Try {
-        val grepPath = executeAndGetOutput(Seq("which", "grep"))
+        val grepPath = executeAndGetOutput(Seq("which", "grep")).stripLineEnd
         executeAndGetOutput(Seq(grepPath, "-m", "1", "model name", "/proc/cpuinfo"))
+          .stripLineEnd.replaceFirst("model name[\\s*]:[\\s*]", "")
       }.getOrElse("Unknown processor")
     } else {
       System.getenv("PROCESSOR_IDENTIFIER")
     }
+    cpu
   }
 
   /**
-   * Runs a single function `f` for iters, returning the average time the function took and
-   * the rate of the function.
+   * This should return a user helpful JVM & OS information.
+   * This should return something like
+   * "OpenJDK 64-Bit Server VM 1.8.0_65-b17 on Linux 4.1.13-100.fc21.x86_64"
    */
-  def measure(num: Long, iters: Int, outputPerIteration: Boolean)(f: Int => Unit): Result = {
-    val runTimes = ArrayBuffer[Long]()
-    for (i <- 0 until iters + 1) {
-      val start = System.nanoTime()
-
-      f(i)
-
-      val end = System.nanoTime()
-      val runTime = end - start
-      if (i > 0) {
-        runTimes += runTime
-      }
-
-      if (outputPerIteration) {
-        // scalastyle:off
-        println(s"Iteration $i took ${runTime / 1000} microseconds")
-        // scalastyle:on
-      }
-    }
-    val best = runTimes.min
-    val avg = runTimes.sum / iters
-    Result(avg / 1000000.0, num / (best / 1000.0), best / 1000000.0)
+  def getJVMOSInfo(): String = {
+    val vmName = System.getProperty("java.vm.name")
+    val runtimeVersion = System.getProperty("java.runtime.version")
+    val osName = System.getProperty("os.name")
+    val osVersion = System.getProperty("os.version")
+    s"${vmName} ${runtimeVersion} on ${osName} ${osVersion}"
   }
 }

--- a/src/main/scala/com/github/sadikovi/spark/benchmark/NetFlowReadBenchmark.scala
+++ b/src/main/scala/com/github/sadikovi/spark/benchmark/NetFlowReadBenchmark.scala
@@ -50,7 +50,7 @@ object NetFlowReadBenchmark {
 
   // Initialize Spark context
   val sparkConf = new SparkConf().
-    setMaster("local[4]").
+    setMaster("local[1]").
     setAppName("spark-netflow-benchmark")
   val spark = SparkSession.builder().config(sparkConf).getOrCreate()
 

--- a/src/test/java/com/github/sadikovi/netflowlib/UtilSuite.java
+++ b/src/test/java/com/github/sadikovi/netflowlib/UtilSuite.java
@@ -16,10 +16,12 @@
 
 package com.github.sadikovi.netflowlib;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Random;
 
 import org.junit.Test;
 import org.junit.Ignore;
@@ -28,6 +30,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.github.sadikovi.netflowlib.util.FilterIterator;
 import com.github.sadikovi.netflowlib.util.SafeIterator;
+import com.github.sadikovi.netflowlib.util.WrappedByteBuf;
 
 public class UtilSuite {
   @Test(expected = NoSuchElementException.class)
@@ -117,7 +120,7 @@ public class UtilSuite {
     values.add("a");
     values.add(null);
     values.add("a");
-    Iterator<String> delegate = new Iterator() {
+    Iterator<String> delegate = new Iterator<String>() {
       private Iterator<String> parent = values.iterator();
       private String current;
 
@@ -156,7 +159,7 @@ public class UtilSuite {
     values.add("a");
     values.add(null);
     values.add("a");
-    Iterator<String> delegate = new Iterator() {
+    Iterator<String> delegate = new Iterator<String>() {
       private Iterator<String> parent = values.iterator();
 
       @Override
@@ -182,5 +185,25 @@ public class UtilSuite {
 
     // Expect one record only, since second record fails with null pointer exception
     assertEquals(count, 1);
+  }
+
+  @Test
+  public void testWrappedByteBufGetters() {
+    // test wrapped byte buf functionality
+    byte[] bytes = new byte[1024];
+    Random rand = new Random();
+    for (int i = 0; i <= bytes.length - 4; i++) {
+      rand.nextBytes(bytes);
+      WrappedByteBuf buf = new WrappedByteBuf(bytes);
+      ByteBuffer javaBuf = ByteBuffer.wrap(bytes);
+
+      assertSame(buf.array(), bytes);
+      assertEquals(buf.getByte(i), javaBuf.get(i));
+      assertEquals(buf.getUnsignedByte(i), (short) (javaBuf.get(i) & 0xff));
+      assertEquals(buf.getShort(i), javaBuf.getShort(i));
+      assertEquals(buf.getUnsignedShort(i), javaBuf.getShort(i) & 0xffff);
+      assertEquals(buf.getInt(i), javaBuf.getInt(i));
+      assertEquals(buf.getUnsignedInt(i), javaBuf.getInt(i) & 0xffffffffL);
+    }
   }
 }

--- a/src/test/java/com/github/sadikovi/netflowlib/UtilSuite.java
+++ b/src/test/java/com/github/sadikovi/netflowlib/UtilSuite.java
@@ -26,6 +26,7 @@ import java.util.Random;
 
 import org.junit.Test;
 import org.junit.Ignore;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertEquals;
 
@@ -189,8 +190,7 @@ public class UtilSuite {
   }
 
   @Test
-  public void testWrappedByteBufGetters() {
-    // test wrapped byte buf functionality
+  public void testWrappedByteBufGetValue() {
     byte[] bytes = new byte[1024];
     Random rand = new Random();
     // check big endian
@@ -222,5 +222,61 @@ public class UtilSuite {
       assertEquals(buf.getInt(i), javaBuf.getInt(i));
       assertEquals(buf.getUnsignedInt(i), javaBuf.getInt(i) & 0xffffffffL);
     }
+  }
+
+  @Test
+  public void testWrappedByteBufGetBytesBigEndian() {
+    byte[] bytes = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+    WrappedByteBuf buf = WrappedByteBuf.init(bytes, ByteOrder.BIG_ENDIAN);
+    ByteBuffer javaBuf = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN);
+
+    byte[] dst1 = new byte[10];
+    byte[] dst2 = new byte[10];
+
+    buf.getBytes(0, dst1, 0, dst1.length);
+    javaBuf.position(0);
+    javaBuf.get(dst2, 0, dst2.length);
+    assertArrayEquals(dst1, dst2);
+
+    buf.getBytes(4, dst1, 1, 2);
+    javaBuf.position(4);
+    javaBuf.get(dst2, 1, 2);
+    assertArrayEquals(dst1, dst2);
+
+    buf.getBytes(8, dst1, 8, 1);
+    javaBuf.position(8);
+    javaBuf.get(dst2, 8, 1);
+    assertArrayEquals(dst1, dst2);
+
+    // array should not be modified
+    assertArrayEquals(buf.array(), new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 0});
+  }
+
+  @Test
+  public void testWrappedByteBufGetBytesLittleEndian() {
+    byte[] bytes = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+    WrappedByteBuf buf = WrappedByteBuf.init(bytes, ByteOrder.LITTLE_ENDIAN);
+    ByteBuffer javaBuf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+
+    byte[] dst1 = new byte[10];
+    byte[] dst2 = new byte[10];
+
+    buf.getBytes(0, dst1, 0, dst1.length);
+    javaBuf.position(0);
+    javaBuf.get(dst2, 0, dst2.length);
+    assertArrayEquals(dst1, dst2);
+
+    buf.getBytes(4, dst1, 1, 2);
+    javaBuf.position(4);
+    javaBuf.get(dst2, 1, 2);
+    assertArrayEquals(dst1, dst2);
+
+    buf.getBytes(8, dst1, 8, 1);
+    javaBuf.position(8);
+    javaBuf.get(dst2, 8, 1);
+    assertArrayEquals(dst1, dst2);
+
+    // array should not be modified
+    assertArrayEquals(buf.array(), new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 0});
   }
 }

--- a/src/test/java/com/github/sadikovi/netflowlib/UtilSuite.java
+++ b/src/test/java/com/github/sadikovi/netflowlib/UtilSuite.java
@@ -17,6 +17,7 @@
 package com.github.sadikovi.netflowlib;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -192,10 +193,26 @@ public class UtilSuite {
     // test wrapped byte buf functionality
     byte[] bytes = new byte[1024];
     Random rand = new Random();
+    // check big endian
     for (int i = 0; i <= bytes.length - 4; i++) {
       rand.nextBytes(bytes);
-      WrappedByteBuf buf = new WrappedByteBuf(bytes);
-      ByteBuffer javaBuf = ByteBuffer.wrap(bytes);
+      WrappedByteBuf buf = WrappedByteBuf.init(bytes, ByteOrder.BIG_ENDIAN);
+      ByteBuffer javaBuf = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN);
+
+      assertSame(buf.array(), bytes);
+      assertEquals(buf.getByte(i), javaBuf.get(i));
+      assertEquals(buf.getUnsignedByte(i), (short) (javaBuf.get(i) & 0xff));
+      assertEquals(buf.getShort(i), javaBuf.getShort(i));
+      assertEquals(buf.getUnsignedShort(i), javaBuf.getShort(i) & 0xffff);
+      assertEquals(buf.getInt(i), javaBuf.getInt(i));
+      assertEquals(buf.getUnsignedInt(i), javaBuf.getInt(i) & 0xffffffffL);
+    }
+
+    // check little endian
+    for (int i = 0; i <= bytes.length - 4; i++) {
+      rand.nextBytes(bytes);
+      WrappedByteBuf buf = WrappedByteBuf.init(bytes, ByteOrder.LITTLE_ENDIAN);
+      ByteBuffer javaBuf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
 
       assertSame(buf.array(), bytes);
       assertEquals(buf.getByte(i), javaBuf.get(i));


### PR DESCRIPTION
This PR updates IO in netflow library by using `WrappedByteBuf` and removing `if-else` statement in record materializer. Nettty `ByteBuf` usage is removed as well.

Also updated benchmark to latest version. Benchmark values show slightly better figures compare to master branch (see updated README).