### PR TITLE
Count with zero columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ class from `NetFlowReader.getHeader()`, see class for more information on flags 
 
 Here is the general usage pattern:
 ```scala
-
 import com.github.sadikovi.netflowlib.NetFlowReader
 import com.github.sadikovi.netflowlib.version.NetFlowV5
 

--- a/src/main/java/com/github/sadikovi/netflowlib/ScanPlanner.java
+++ b/src/main/java/com/github/sadikovi/netflowlib/ScanPlanner.java
@@ -81,7 +81,7 @@ public final class ScanPlanner implements PredicateTransform {
     // predicate tree and applying statistics to modified predicate; next step is converting
     // predicate tree into inspector tree + mapping of columns to [[ValueInspector]], so it can be
     // used in [[RecordMaterializer]].
-    if (columns == null || columns.length == 0) {
+    if (columns == null) {
       throw new IllegalArgumentException("Expected columns to select, got " + columns +
         ". Make sure that you provide correct Column instances when requesting a scan");
     }

--- a/src/main/scala/com/github/sadikovi/spark/netflow/DefaultSource.scala
+++ b/src/main/scala/com/github/sadikovi/spark/netflow/DefaultSource.scala
@@ -104,8 +104,7 @@ class DefaultSource extends FileFormat with DataSourceRegister {
     // Convert SQL columns to internal mapped columns, also check if statistics are enabled, so
     // schema is adjusted to include statistics columns
     val resolvedColumns: Array[MappedColumn] = if (requiredSchema.isEmpty) {
-      log.info("Required columns are empty, using first column instead")
-      Array(interface.getFirstColumn())
+      Array.empty
     } else {
       requiredSchema.fieldNames.map { col => interface.getColumn(col) }
     }

--- a/src/test/java/com/github/sadikovi/netflowlib/ScanPlannerSuite.java
+++ b/src/test/java/com/github/sadikovi/netflowlib/ScanPlannerSuite.java
@@ -58,14 +58,6 @@ public class ScanPlannerSuite {
     ScanPlanner.buildStrategy(cols, tree, null);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testColumnsEmptyFailure() {
-    IntColumn[] cols = new IntColumn[0];
-    FilterPredicate tree = null;
-
-    ScanPlanner.buildStrategy(cols, tree, null);
-  }
-
   @Test
   public void testSkipScan1() {
     IntColumn[] cols = new IntColumn[] {new IntColumn("col1", 0), new IntColumn("col2", 4)};

--- a/src/test/scala/com/github/sadikovi/spark/netflow/NetFlowSuite.scala
+++ b/src/test/scala/com/github/sadikovi/spark/netflow/NetFlowSuite.scala
@@ -437,7 +437,7 @@ class NetFlowSuite extends SparkNetFlowTestSuite {
     fields3.map(_.convertFunction.isDefined) should be (Array(false, false))
   }
 
-  test("issue #5 - prune only one column when running count directly") {
+  test("issue #5 - prune zero columns when running count directly") {
     val format = new DefaultSource()
     // run test for version 5
     val schema = format.inferSchema(spark, Map("version" -> "5"), Seq.empty)
@@ -446,8 +446,8 @@ class NetFlowSuite extends SparkNetFlowTestSuite {
       Map.empty, new Configuration(false))
     val iter = func(PartitionedFile(InternalRow.empty, path1, 0, 1024))
     iter.hasNext should be (true)
-    // should be only one column (unix_secs) which is "0" for generated data
-    iter.next() should be (InternalRow(0))
+    // should be no columns in internal row
+    iter.next() should be (InternalRow())
   }
 
   test("filter values when reading file, if predicate-pushdown is enabled") {


### PR DESCRIPTION
Currently, when we run count, we use single column `unix_secs` to return as part of `Array[Object]`. This PR updates scan planner and default source, so we run count on 0 columns, each `InternalRow` is empty.